### PR TITLE
New pointers interface & updated AO

### DIFF
--- a/include/qmckl_ao_gpu.h
+++ b/include/qmckl_ao_gpu.h
@@ -27,16 +27,14 @@ qmckl_exit_code qmckl_ao_polynomial_transp_vgl_hpc_device(
 	const int64_t ldl, double *restrict const VGL, const int64_t ldv);
 
 qmckl_exit_code qmckl_compute_ao_vgl_gaussian_device(
-	const qmckl_context_device context, const int64_t ao_num,
-	const int64_t shell_num, const int32_t *restrict prim_num_per_nucleus,
-	const int64_t point_num, const int64_t nucl_num,
-	const double *restrict coord, const double *restrict nucl_coord,
-	const int64_t *restrict nucleus_index,
+	const qmckl_context context, const int64_t ao_num, const int64_t shell_num,
+	const int32_t *restrict prim_num_per_nucleus, const int64_t point_num,
+	const int64_t nucl_num, const double *restrict coord,
+	const double *restrict nucl_coord, const int64_t *restrict nucleus_index,
 	const int64_t *restrict nucleus_shell_num, const double *nucleus_range,
 	const int32_t *restrict nucleus_max_ang_mom,
 	const int32_t *restrict shell_ang_mom, const double *restrict ao_factor,
-	const qmckl_matrix expo_per_nucleus, const qmckl_tensor coef_per_nucleus,
-	double *restrict const ao_vgl);
+	double *shell_vgl, double *restrict const ao_vgl);
 
 qmckl_exit_code
 qmckl_provide_ao_basis_ao_vgl_device(qmckl_context_device context);

--- a/include/qmckl_ao_gpu.h
+++ b/include/qmckl_ao_gpu.h
@@ -41,7 +41,6 @@ qmckl_exit_code qmckl_compute_ao_vgl_gaussian_device(
 qmckl_exit_code
 qmckl_provide_ao_basis_ao_vgl_device(qmckl_context_device context);
 
-qmckl_exit_code
-qmckl_get_ao_basis_ao_vgl_device(qmckl_context_device context,
-									 double *const ao_vgl,
-									 const int64_t size_max);
+qmckl_exit_code qmckl_get_ao_basis_ao_vgl_device(qmckl_context_device context,
+												 double *const ao_vgl,
+												 const int64_t size_max);

--- a/include/qmckl_blas_device.h
+++ b/include/qmckl_blas_device.h
@@ -23,39 +23,38 @@
 #include "qmckl_memory_device.h"
 
 qmckl_vector qmckl_vector_alloc_device(qmckl_context_device context,
-										   const int64_t size);
+									   const int64_t size);
 
 qmckl_exit_code qmckl_vector_free_device(qmckl_context_device context,
-											 qmckl_vector *vector);
+										 qmckl_vector *vector);
 
 qmckl_exit_code
 qmckl_vector_of_double_device(const qmckl_context_device context,
-								  const double *target, const int64_t size_max,
-								  qmckl_vector *vector_out);
+							  const double *target, const int64_t size_max,
+							  qmckl_vector *vector_out);
 
 qmckl_matrix qmckl_matrix_alloc_device(qmckl_context_device context,
-										   const int64_t size1,
-										   const int64_t size2);
+									   const int64_t size1,
+									   const int64_t size2);
 
 qmckl_exit_code qmckl_matrix_free_device(qmckl_context_device context,
-											 qmckl_matrix *matrix);
+										 qmckl_matrix *matrix);
 
 qmckl_matrix qmckl_matrix_set_device(qmckl_matrix matrix, double value);
 
 qmckl_exit_code
 qmckl_matrix_of_double_device(const qmckl_context_device context,
-								  const double *target, const int64_t size_max,
-								  qmckl_matrix *matrix_out);
+							  const double *target, const int64_t size_max,
+							  qmckl_matrix *matrix_out);
 
 qmckl_exit_code qmckl_transpose_device(qmckl_context_device context,
-										   const qmckl_matrix A,
-										   qmckl_matrix At);
+									   const qmckl_matrix A, qmckl_matrix At);
 
 qmckl_tensor qmckl_tensor_alloc_device(qmckl_context context,
-										   const int64_t order,
-										   const int64_t *size);
+									   const int64_t order,
+									   const int64_t *size);
 
 qmckl_exit_code qmckl_tensor_free_device(qmckl_context_device context,
-											 qmckl_tensor *tensor);
+										 qmckl_tensor *tensor);
 
 qmckl_tensor qmckl_tensor_set_device(qmckl_tensor tensor, double value);

--- a/include/qmckl_context_device.h
+++ b/include/qmckl_context_device.h
@@ -19,14 +19,12 @@
 #include "qmckl_context_private_type.h"
 #include "qmckl_memory_private_func.h"
 
-
 typedef int64_t qmckl_context_device;
 
 typedef struct {
 	size_t device_id;
 	qmckl_memory_struct memory;
 } qmckl_context_device_struct;
-
 
 qmckl_exit_code
 qmckl_context_destroy_omp_device(const qmckl_context_device context);

--- a/include/qmckl_gpu.h
+++ b/include/qmckl_gpu.h
@@ -28,8 +28,8 @@ qmckl_context_destroy_device(const qmckl_context_device context);
 //**********
 
 qmckl_exit_code qmckl_trexio_read_device(const qmckl_context_device context,
-											 const char *file_name,
-											 const int64_t size_max);
+										 const char *file_name,
+										 const int64_t size_max);
 
 //**********
 // AO
@@ -40,13 +40,14 @@ qmckl_get_ao_basis_ao_num_device(const qmckl_context_device context,
 								 int64_t *const ao_num);
 qmckl_exit_code
 qmckl_get_ao_basis_ao_num_device(const qmckl_context_device context,
-									 int64_t *const ao_num);
+								 int64_t *const ao_num);
 
 qmckl_exit_code qmckl_get_ao_basis_ao_vgl_inplace_offload(
 	qmckl_context context, double *const ao_vgl, const int64_t size_max);
 
-qmckl_exit_code qmckl_get_ao_basis_ao_vgl_device(
-	qmckl_context_device context, double *const ao_vgl, const int64_t size_max);
+qmckl_exit_code qmckl_get_ao_basis_ao_vgl_device(qmckl_context_device context,
+												 double *const ao_vgl,
+												 const int64_t size_max);
 
 //**********
 // JASTROW
@@ -58,11 +59,13 @@ qmckl_exit_code qmckl_get_ao_basis_ao_vgl_device(
 // ELECTRON
 //**********
 
-qmckl_exit_code qmckl_set_electron_coord_device(
-	qmckl_context_device context, const char transp, const int64_t walk_num,
-	const double *coord, const int64_t size_max);
+qmckl_exit_code qmckl_set_electron_coord_device(qmckl_context_device context,
+												const char transp,
+												const int64_t walk_num,
+												const double *coord,
+												const int64_t size_max);
 
 qmckl_exit_code qmckl_set_point_device(qmckl_context_device context,
-										   const char transp, const int64_t num,
-										   const double *coord,
-										   const int64_t size_max);
+									   const char transp, const int64_t num,
+									   const double *coord,
+									   const int64_t size_max);

--- a/include/qmckl_jastrow_gpu.h
+++ b/include/qmckl_jastrow_gpu.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 // This file contains prototypes for the Jastrow functions
 // TODO Get up to date with the latest Jastrow rework
 
@@ -18,12 +17,12 @@
 #include "qmckl_jastrow_private_type.h"
 #include "qmckl_jastrow_private_func.h"
 
-
-qmckl_exit_code qmckl_compute_tmp_c_offload(
-	const qmckl_context context, const int64_t cord_num, const int64_t elec_num,
-	const int64_t nucl_num, const int64_t walk_num,
-	const double *een_rescaled_e, const double *een_rescaled_n,
-	double *const tmp_c);
+qmckl_exit_code
+qmckl_compute_tmp_c_offload(const qmckl_context context, const int64_t cord_num,
+							const int64_t elec_num, const int64_t nucl_num,
+							const int64_t walk_num,
+							const double *een_rescaled_e,
+							const double *een_rescaled_n, double *const tmp_c);
 
 qmckl_exit_code qmckl_compute_dtmp_c_offload(
 	const qmckl_context context, const int64_t cord_num, const int64_t elec_num,
@@ -35,16 +34,15 @@ qmckl_exit_code qmckl_provide_tmp_c_offload(qmckl_context context);
 
 qmckl_exit_code qmckl_provide_dtmp_c_offload(qmckl_context context);
 
-qmckl_exit_code
-qmckl_provide_factor_een_deriv_e_offload(qmckl_context context);
+qmckl_exit_code qmckl_provide_factor_een_deriv_e_offload(qmckl_context context);
 
 qmckl_exit_code qmckl_get_jastrow_tmp_c_offload(qmckl_context context,
-													double *const tmp_c);
+												double *const tmp_c);
 
 qmckl_exit_code qmckl_get_jastrow_dtmp_c_offload(qmckl_context context,
-													 double *const dtmp_c);
+												 double *const dtmp_c);
 
-qmckl_exit_code qmckl_get_jastrow_factor_een_deriv_e_offload(
-	qmckl_context context, double *const factor_een_deriv_e,
-	const int64_t size_max);
-
+qmckl_exit_code
+qmckl_get_jastrow_factor_een_deriv_e_offload(qmckl_context context,
+											 double *const factor_een_deriv_e,
+											 const int64_t size_max);

--- a/include/qmckl_memory_device.h
+++ b/include/qmckl_memory_device.h
@@ -17,7 +17,6 @@
 
 #include "qmckl_context_device.h"
 
-
 /* Allocs & frees */
 
 void *qmckl_malloc_host(qmckl_context_device context,
@@ -26,20 +25,16 @@ void *qmckl_malloc_host(qmckl_context_device context,
 qmckl_exit_code qmckl_free_host(qmckl_context_device context, void *const ptr);
 
 void *qmckl_malloc_device(qmckl_context_device context,
-							  const qmckl_memory_info_struct info);
+						  const qmckl_memory_info_struct info);
 
 qmckl_exit_code qmckl_free_device(qmckl_context_device context,
-									  void *const ptr);
-
+								  void *const ptr);
 
 /* Memcpys */
 
-qmckl_exit_code qmckl_memcpy_H2D(qmckl_context_device context,
-								 void *const dest, void *const src,
-								 size_t size);
-qmckl_exit_code qmckl_memcpy_D2H(qmckl_context_device context,
-								 void *const dest, void *const src,
-								 size_t size);
-qmckl_exit_code qmckl_memcpy_D2D(qmckl_context_device context,
-								 void *const dest, void *const src,
-								 size_t size);
+qmckl_exit_code qmckl_memcpy_H2D(qmckl_context_device context, void *const dest,
+								 void *const src, size_t size);
+qmckl_exit_code qmckl_memcpy_D2H(qmckl_context_device context, void *const dest,
+								 void *const src, size_t size);
+qmckl_exit_code qmckl_memcpy_D2D(qmckl_context_device context, void *const dest,
+								 void *const src, size_t size);

--- a/include/qmckl_trexio_device.h
+++ b/include/qmckl_trexio_device.h
@@ -36,18 +36,19 @@ qmckl_exit_code qmckl_set_electron_num_device(qmckl_context_device context,
 											  const int64_t down_num);
 
 qmckl_exit_code qmckl_set_electron_num_device(qmckl_context_device context,
-												  const int64_t up_num,
-												  const int64_t down_num);
+											  const int64_t up_num,
+											  const int64_t down_num);
 
-qmckl_exit_code qmckl_set_electron_coord_device(
-	qmckl_context_device context, const char transp, const int64_t walk_num,
-	const double *coord, const int64_t size_max);
+qmckl_exit_code qmckl_set_electron_coord_device(qmckl_context_device context,
+												const char transp,
+												const int64_t walk_num,
+												const double *coord,
+												const int64_t size_max);
 
 qmckl_exit_code qmckl_set_point_device(qmckl_context_device context,
-										   const char transp, const int64_t num,
-										   const double *coord,
-										   const int64_t size_max);
-
+									   const char transp, const int64_t num,
+									   const double *coord,
+									   const int64_t size_max);
 
 //**********
 // NUCLEUS GETTERS/SETTERS
@@ -55,24 +56,22 @@ qmckl_exit_code qmckl_set_point_device(qmckl_context_device context,
 
 qmckl_exit_code qmckl_get_nucleus_num_device(const qmckl_context_device context,
 											 int64_t *const num);
-qmckl_exit_code
-qmckl_get_nucleus_num_device(const qmckl_context_device context,
-								 int64_t *const num);
+qmckl_exit_code qmckl_get_nucleus_num_device(const qmckl_context_device context,
+											 int64_t *const num);
 
 qmckl_exit_code qmckl_set_nucleus_num_device(qmckl_context_device context,
 											 const int64_t num);
 
 qmckl_exit_code qmckl_set_nucleus_num_device(qmckl_context_device context,
-												 const int64_t num);
+											 const int64_t num);
 
-qmckl_exit_code
-qmckl_set_nucleus_charge_device(qmckl_context_device context,
-									const double *charge,
-									const int64_t size_max);
+qmckl_exit_code qmckl_set_nucleus_charge_device(qmckl_context_device context,
+												const double *charge,
+												const int64_t size_max);
 qmckl_exit_code qmckl_set_nucleus_coord_device(qmckl_context_device context,
-												   const char transp,
-												   const double *coord,
-												   const int64_t size_max);
+											   const char transp,
+											   const double *coord,
+											   const int64_t size_max);
 
 qmckl_exit_code
 qmckl_finalize_nucleus_basis_hpc_device(qmckl_context_device context);
@@ -88,7 +87,7 @@ qmckl_get_ao_basis_ao_num_device(const qmckl_context_device context,
 								 int64_t *const ao_num);
 qmckl_exit_code
 qmckl_get_ao_basis_ao_num_device(const qmckl_context_device context,
-									 int64_t *const ao_num);
+								 int64_t *const ao_num);
 
 qmckl_exit_code
 qmckl_finalize_ao_basis_hpc_device(qmckl_context_device context);
@@ -96,13 +95,12 @@ qmckl_finalize_ao_basis_hpc_device(qmckl_context_device context);
 qmckl_exit_code qmckl_finalize_ao_basis_device(qmckl_context_device context);
 
 qmckl_exit_code qmckl_set_ao_basis_type_device(qmckl_context_device context,
-												   const char basis_type);
+											   const char basis_type);
 qmckl_exit_code
 qmckl_set_ao_basis_shell_num_device(qmckl_context_device context,
-										const int64_t shell_num);
-qmckl_exit_code
-qmckl_set_ao_basis_prim_num_device(qmckl_context_device context,
-									   const int64_t prim_num);
+									const int64_t shell_num);
+qmckl_exit_code qmckl_set_ao_basis_prim_num_device(qmckl_context_device context,
+												   const int64_t prim_num);
 
 qmckl_exit_code
 qmckl_get_ao_basis_ao_num_device(const qmckl_context_device context,
@@ -111,63 +109,68 @@ qmckl_exit_code
 qmckl_get_ao_basis_ao_num_device(const qmckl_context_device context,
 								 int64_t *const ao_num);
 
+qmckl_exit_code qmckl_set_ao_basis_ao_num_device(qmckl_context_device context,
+												 const int64_t ao_num);
 qmckl_exit_code
-qmckl_set_ao_basis_ao_num_device(qmckl_context_device context,
-									 const int64_t ao_num);
-qmckl_exit_code qmckl_set_ao_basis_nucleus_index_device(
-	qmckl_context_device context, const int64_t *nucleus_index,
-	const int64_t size_max);
-qmckl_exit_code qmckl_set_ao_basis_nucleus_shell_num_device(
-	qmckl_context_device context, const int64_t *nucleus_shell_num,
-	const int64_t size_max);
-qmckl_exit_code qmckl_set_ao_basis_shell_ang_mom_device(
-	qmckl_context_device context, const int32_t *shell_ang_mom,
-	const int64_t size_max);
-qmckl_exit_code qmckl_set_ao_basis_shell_prim_num_device(
-	qmckl_context_device context, const int64_t *shell_prim_num,
-	const int64_t size_max);
-qmckl_exit_code qmckl_set_ao_basis_shell_prim_index_device(
-	qmckl_context context, const int64_t *shell_prim_index,
-	const int64_t size_max);
-qmckl_exit_code qmckl_set_ao_basis_shell_factor_device(
-	qmckl_context_device context, const double *shell_factor,
-	const int64_t size_max);
+qmckl_set_ao_basis_nucleus_index_device(qmckl_context_device context,
+										const int64_t *nucleus_index,
+										const int64_t size_max);
 qmckl_exit_code
-qmckl_set_ao_basis_exponent_device(qmckl_context_device context,
-									   const double *exponent,
+qmckl_set_ao_basis_nucleus_shell_num_device(qmckl_context_device context,
+											const int64_t *nucleus_shell_num,
+											const int64_t size_max);
+qmckl_exit_code
+qmckl_set_ao_basis_shell_ang_mom_device(qmckl_context_device context,
+										const int32_t *shell_ang_mom,
+										const int64_t size_max);
+qmckl_exit_code
+qmckl_set_ao_basis_shell_prim_num_device(qmckl_context_device context,
+										 const int64_t *shell_prim_num,
+										 const int64_t size_max);
+qmckl_exit_code
+qmckl_set_ao_basis_shell_prim_index_device(qmckl_context context,
+										   const int64_t *shell_prim_index,
+										   const int64_t size_max);
+qmckl_exit_code
+qmckl_set_ao_basis_shell_factor_device(qmckl_context_device context,
+									   const double *shell_factor,
 									   const int64_t size_max);
-qmckl_exit_code qmckl_set_ao_basis_coefficient_device(
-	qmckl_context_device context, const double *coefficient,
-	const int64_t size_max);
-qmckl_exit_code qmckl_set_ao_basis_prim_factor_device(
-	qmckl_context context, const double *prim_factor, const int64_t size_max);
+qmckl_exit_code qmckl_set_ao_basis_exponent_device(qmckl_context_device context,
+												   const double *exponent,
+												   const int64_t size_max);
+qmckl_exit_code
+qmckl_set_ao_basis_coefficient_device(qmckl_context_device context,
+									  const double *coefficient,
+									  const int64_t size_max);
+qmckl_exit_code qmckl_set_ao_basis_prim_factor_device(qmckl_context context,
+													  const double *prim_factor,
+													  const int64_t size_max);
 qmckl_exit_code
 qmckl_set_ao_basis_ao_factor_device(qmckl_context_device context,
-										const double *ao_factor,
-										const int64_t size_max);
+									const double *ao_factor,
+									const int64_t size_max);
 
 //**********
 // MO GETTERS/SETTERS
 //**********
 
 qmckl_exit_code qmckl_finalize_mo_basis_device(qmckl_context_device context);
+qmckl_exit_code qmckl_set_mo_basis_mo_num_device(qmckl_context_device context,
+												 const int64_t mo_num);
 qmckl_exit_code
-qmckl_set_mo_basis_mo_num_device(qmckl_context_device context,
-									 const int64_t mo_num);
-qmckl_exit_code qmckl_set_mo_basis_coefficient_device(
-	qmckl_context context, const double *coefficient);
+qmckl_set_mo_basis_coefficient_device(qmckl_context context,
+									  const double *coefficient);
 
 //**********
 // CONTEXT FILL
 //**********
 
-qmckl_exit_code
-qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
-									   trexio_t *const file);
+qmckl_exit_code qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
+												   trexio_t *const file);
 qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
-												  trexio_t *const file);
+											  trexio_t *const file);
 qmckl_exit_code qmckl_trexio_read_mo_X_device(qmckl_context_device context,
-												  trexio_t *const file);
+											  trexio_t *const file);
 qmckl_exit_code qmckl_trexio_read_device(const qmckl_context_device context,
-											 const char *file_name,
-											 const int64_t size_max);
+										 const char *file_name,
+										 const int64_t size_max);

--- a/src/qmckl_ao_omp_device.c
+++ b/src/qmckl_ao_omp_device.c
@@ -123,7 +123,7 @@ qmckl_exit_code qmckl_ao_polynomial_transp_vgl_hpc_device(
 }
 #pragma omp end declare target
 
-qmckl_exit_code qmckl_compute_ao_vgl_gaussian_device_device(
+qmckl_exit_code qmckl_compute_ao_vgl_gaussian_device(
 	const qmckl_context_device context, const int64_t ao_num,
 	const int64_t shell_num, const int32_t *restrict prim_num_per_nucleus,
 	const int64_t point_num, const int64_t nucl_num,
@@ -135,11 +135,9 @@ qmckl_exit_code qmckl_compute_ao_vgl_gaussian_device_device(
 	const qmckl_matrix expo_per_nucleus, const qmckl_tensor coef_per_nucleus,
 	double *restrict const ao_vgl) {
 
-
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 	assert(ctx != NULL);
 	int device_id = qmckl_get_device_id(context);
-
 
 	int32_t *lstart_h = omp_target_alloc(32 * sizeof(int32_t), device_id);
 
@@ -598,8 +596,7 @@ qmckl_provide_ao_basis_ao_vgl_device(qmckl_context_device context) {
 			qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 			mem_info.size =
 				ctx->ao_basis.ao_num * 5 * ctx->point.num * sizeof(double);
-			double *ao_vgl =
-				(double *)qmckl_malloc_device(context, mem_info);
+			double *ao_vgl = (double *)qmckl_malloc_device(context, mem_info);
 
 			if (ao_vgl == NULL) {
 				return qmckl_failwith(context, QMCKL_ALLOCATION_FAILED,
@@ -609,7 +606,7 @@ qmckl_provide_ao_basis_ao_vgl_device(qmckl_context_device context) {
 		}
 
 		if (ctx->ao_basis.type == 'G') {
-			rc = qmckl_compute_ao_vgl_gaussian_device_device(
+			rc = qmckl_compute_ao_vgl_gaussian_device(
 				context, ctx->ao_basis.ao_num, ctx->ao_basis.shell_num,
 				ctx->ao_basis.prim_num_per_nucleus, ctx->point.num,
 				ctx->nucleus.num, ctx->point.coord.data,
@@ -638,10 +635,9 @@ qmckl_provide_ao_basis_ao_vgl_device(qmckl_context_device context) {
 // GET
 //**********
 
-qmckl_exit_code
-qmckl_get_ao_basis_ao_vgl_device(qmckl_context_device context,
-									 double *const ao_vgl,
-									 const int64_t size_max) {
+qmckl_exit_code qmckl_get_ao_basis_ao_vgl_device(qmckl_context_device context,
+												 double *const ao_vgl,
+												 const int64_t size_max) {
 
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,

--- a/src/qmckl_ao_omp_device.c
+++ b/src/qmckl_ao_omp_device.c
@@ -4,563 +4,421 @@
 // COMPUTE
 //**********
 
-// TODO Inline this function
-#pragma omp declare target
-qmckl_exit_code qmckl_ao_polynomial_transp_vgl_hpc_device(
-	const qmckl_context_device context, const double *restrict X,
-	const double *restrict R, const int32_t lmax, int64_t *restrict n,
-	const int64_t ldl, double *restrict const VGL, const int64_t ldv) {
+/* shell_vgl */
 
-	// assert (ctx != NULL && X != NULL && R != NULL && n != NULL && VGL !=
-	// NULL);
-	if (lmax < 0)
-		return QMCKL_INVALID_ARG_4;
-	if (ldl < 3)
-		return QMCKL_INVALID_ARG_7;
+qmckl_exit_code qmckl_compute_ao_basis_shell_gaussian_vgl_device(
+	qmckl_context_device context, int prim_num, int shell_num, int point_num,
+	int nucl_num, int64_t *nucleus_shell_num, int64_t *nucleus_index,
+	double *nucleus_range, int64_t *shell_prim_index, int64_t *shell_prim_num,
+	double *coord, double *nucl_coord, double *expo, double *coef_normalized,
+	double *shell_vgl) {
 
-	int32_t m;
+	int ishell_start, ishell_end;
+	int iprim_start, iprim_end;
+	double x, y, z, two_a, ar2, r2, v, cutoff;
 
-	const int32_t size_max = (lmax + 1) * (lmax + 2) * (lmax + 3) / 6;
-	if (ldv < size_max)
-		return QMCKL_INVALID_ARG_9;
+	qmckl_exit_code info = QMCKL_SUCCESS;
 
-	double *restrict const vgl1 = VGL;
-	double *restrict const vgl2 = VGL + ldv;
-	double *restrict const vgl3 = VGL + (ldv << 1);
-	double *restrict const vgl4 = VGL + ldv + (ldv << 1);
-	double *restrict const vgl5 = VGL + (ldv << 2);
-
-	const double Y[3] = {X[0] - R[0], X[1] - R[1], X[2] - R[2]};
-
-	// assert(size_max > lmax + 3);
-
-	for (int32_t k = 0; k < 4; ++k) {
-		vgl2[k] = 0.0;
-		vgl3[k] = 0.0;
-		vgl4[k] = 0.0;
-		vgl5[k] = 0.0;
-	}
-	vgl1[0] = 1.0;
-	vgl1[1] = Y[0];
-	vgl1[2] = Y[1];
-	vgl1[3] = Y[2];
-
-	vgl2[1] = 1.0;
-	vgl3[2] = 1.0;
-	vgl4[3] = 1.0;
-	m = 4;
-
-	double pow_1, pow_2, pow_3;
-	double dd = 2.0;
-
-	for (int32_t d = 2; d <= lmax; ++d) {
-		double da = dd;
-
-		for (int32_t a = d; a >= 0; --a) {
-			double db = dd - da;
-
-			for (int32_t b = d - a; b >= 0; --b) {
-				const int32_t c = d - a - b;
-				const double dc = dd - da - db;
-
-				// Compute pow_1 up to the power of a (a loop)
-				pow_1 = 1.0f;
-				for (int i = 0; i < a; ++i) {
-					pow_1 = pow_1 * Y[0];
-				}
-				// Compute pow_2 up to the power of b (b loop)
-				pow_2 = 1.0f;
-				for (int i = 0; i < b; ++i) {
-					pow_2 = pow_2 * Y[1];
-				}
-				// Compute pow_3 up to the power of c (c loop)
-				pow_3 = 1.0f;
-				for (int i = 0; i < c; ++i) {
-					pow_3 = pow_3 * Y[2];
-				}
-
-				double xy = pow_1 * pow_2;
-				double yz = pow_2 * pow_3;
-				double xz = pow_1 * pow_3;
-
-				vgl1[m] = xy * pow_3;
-
-				xy *= dc;
-				xz *= db;
-				yz *= da;
-
-				if (a >= 2)
-					vgl2[m] = pow_1 / Y[0] * yz;
-				else
-					vgl2[m] = 1.0 * yz;
-				if (b >= 2)
-					vgl3[m] = pow_2 / Y[1] * xz;
-				else
-					vgl3[m] = 1.0 * xz;
-				if (c >= 2)
-					vgl4[m] = pow_3 / Y[2] * xy;
-				else
-					vgl4[m] = 1.0 * xy;
-
-				double pow_1_tmp = (a >= 3) ? pow_1 : 1.;
-				double pow_2_tmp = (b >= 3) ? pow_2 : 1.;
-				double pow_3_tmp = (c >= 3) ? pow_3 : 1.;
-
-				vgl5[m] = (da - 1.) * pow_1_tmp * yz +
-						  (db - 1.) * pow_2_tmp * xz +
-						  (dc - 1.) * pow_3_tmp * xy;
-
-				db -= 1.0;
-				++m;
-			}
-			da -= 1.0;
-		}
-		dd += 1.0;
-	}
-
-	*n = m;
-	return QMCKL_SUCCESS;
-}
-#pragma omp end declare target
-
-qmckl_exit_code qmckl_compute_ao_vgl_gaussian_device(
-	const qmckl_context_device context, const int64_t ao_num,
-	const int64_t shell_num, const int32_t *restrict prim_num_per_nucleus,
-	const int64_t point_num, const int64_t nucl_num,
-	const double *restrict coord, const double *restrict nucl_coord,
-	const int64_t *restrict nucleus_index,
-	const int64_t *restrict nucleus_shell_num, const double *nucleus_range,
-	const int32_t *restrict nucleus_max_ang_mom,
-	const int32_t *restrict shell_ang_mom, const double *restrict ao_factor,
-	const qmckl_matrix expo_per_nucleus, const qmckl_tensor coef_per_nucleus,
-	double *restrict const ao_vgl) {
-
-	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
-	assert(ctx != NULL);
-	int device_id = qmckl_get_device_id(context);
-
-	int32_t *lstart_h = omp_target_alloc(32 * sizeof(int32_t), device_id);
-
-#pragma omp target is_device_ptr(lstart_h)
-	{
-#pragma omp teams distribute parallel for simd
-		for (int32_t l = 0; l < 32; ++l) {
-			lstart_h[l] = l * (l + 1) * (l + 2) / 6;
-		}
-	}
-
-	int64_t *ao_index =
-		omp_target_alloc((shell_num + 1) * sizeof(int64_t), device_id);
-
-	int64_t size_max = 0;
-	int64_t prim_max = 0;
-	int64_t shell_max = 0;
-	int64_t k = 0;
-
-	int64_t *size_max_ptr = omp_target_alloc(sizeof(int64_t), device_id);
-	int64_t *prim_max_ptr = omp_target_alloc(sizeof(int64_t), device_id);
-	int64_t *shell_max_ptr = omp_target_alloc(sizeof(int64_t), device_id);
-	int64_t *k_ptr = omp_target_alloc(sizeof(int64_t), device_id);
+	// Don't compute exponentials when the result will be almost zero.
+	// TODO : Use numerical precision here
+	cutoff = -log(1e-12);
 
 #pragma omp target is_device_ptr(                                              \
-	prim_num_per_nucleus, nucleus_shell_num, nucleus_index, ao_index,          \
-	lstart_h, shell_ang_mom, size_max_ptr, prim_max_ptr, shell_max_ptr, k_ptr)
+	nucleus_shell_num, nucleus_index, nucleus_range, shell_prim_index,         \
+	shell_prim_num, coord, nucl_coord, expo, coef_normalized, shell_vgl)
 	{
 
-		size_max_ptr[0] = 0;
-		prim_max_ptr[0] = 0;
-		shell_max_ptr[0] = 0;
-		k_ptr[0] = 0;
+#pragma omp teams distribute parallel for simd collapse(2)
+		for (int ipoint = 0; ipoint < point_num; ipoint++) {
 
-		for (int inucl = 0; inucl < nucl_num; ++inucl) {
-			prim_max_ptr[0] = prim_num_per_nucleus[inucl] > prim_max_ptr[0]
-								  ? prim_num_per_nucleus[inucl]
-								  : prim_max_ptr[0];
-			shell_max_ptr[0] = nucleus_shell_num[inucl] > shell_max_ptr[0]
-								   ? nucleus_shell_num[inucl]
-								   : shell_max_ptr[0];
-			int64_t ishell_start = nucleus_index[inucl];
-			int64_t ishell_end =
-				nucleus_index[inucl] + nucleus_shell_num[inucl];
-			for (int64_t ishell = ishell_start; ishell < ishell_end; ++ishell) {
-				const int l = shell_ang_mom[ishell];
-				ao_index[ishell] = k_ptr[0];
-				k_ptr[0] += lstart_h[l + 1] - lstart_h[l];
-				size_max_ptr[0] = size_max_ptr[0] < lstart_h[l + 1]
-									  ? lstart_h[l + 1]
-									  : size_max_ptr[0];
-			}
-		}
+			for (int inucl = 0; inucl < nucl_num; inucl++) {
 
-		ao_index[shell_num] = ao_num + 1;
-	}
+				x = coord[ipoint] - nucl_coord[inucl];
+				y = coord[ipoint + point_num] - nucl_coord[inucl + nucl_num];
+				z = coord[ipoint + 2 * point_num] -
+					nucl_coord[inucl + 2 * nucl_num];
 
-	// Affect _ptr values to host variables
-	omp_target_memcpy(&size_max, size_max_ptr, sizeof(int64_t), 0, 0,
-					  omp_get_initial_device(), device_id);
-	omp_target_memcpy(&prim_max, prim_max_ptr, sizeof(int64_t), 0, 0,
-					  omp_get_initial_device(), device_id);
-	omp_target_memcpy(&shell_max, shell_max_ptr, sizeof(int64_t), 0, 0,
-					  omp_get_initial_device(), device_id);
-	omp_target_memcpy(&k, k_ptr, sizeof(int64_t), 0, 0,
-					  omp_get_initial_device(), device_id);
-
-	omp_target_free(size_max_ptr, device_id);
-	omp_target_free(prim_max_ptr, device_id);
-	omp_target_free(shell_max_ptr, device_id);
-	omp_target_free(k_ptr, device_id);
-
-	/* Don't compute polynomials when the radial part is zero. */
-	double cutoff = -log(1.e-12);
-
-	double *poly_vgl_shared = (double *)omp_target_alloc(
-		point_num * 5 * size_max * sizeof(double), device_id);
-
-	double *coef_mat = (double *)omp_target_alloc(
-		nucl_num * shell_max * prim_max * sizeof(double), device_id);
-
-	double *coef_per_nucleus_data = coef_per_nucleus.data;
-	int coef_per_nucleus_size_0 = coef_per_nucleus.size[0];
-	int coef_per_nucleus_size_1 = coef_per_nucleus.size[1];
-
-#pragma omp target is_device_ptr(coef_mat, coef_per_nucleus_data)
-	{
-#pragma omp teams distribute parallel for simd
-		for (int i = 0; i < nucl_num; ++i) {
-			for (int j = 0; j < shell_max; ++j) {
-				for (int k = 0; k < prim_max; ++k) {
-					coef_mat[i * shell_max * prim_max + j * prim_max + k] =
-						coef_per_nucleus_data
-							[(k) + coef_per_nucleus_size_0 *
-									   ((j) + coef_per_nucleus_size_1 * (i))];
-				}
-			}
-		}
-	}
-
-	double *expo_per_nucleus_data = expo_per_nucleus.data;
-	int expo_per_nucleus_size_0 = expo_per_nucleus.size[0];
-
-#pragma omp target is_device_ptr(                                              \
-	coef_mat, ao_index, poly_vgl_shared, expo_per_nucleus_data,                \
-	prim_num_per_nucleus, coord, nucl_coord, nucleus_index, nucleus_shell_num, \
-	nucleus_range, nucleus_max_ang_mom, shell_ang_mom, ao_factor, ao_vgl)
-	{
-
-#pragma omp teams distribute parallel for simd
-		for (int64_t ipoint = 0; ipoint < point_num; ++ipoint) {
-
-			double *poly_vgl = &(poly_vgl_shared[ipoint * 5 * size_max]);
-
-			int32_t lstart[32];
-			for (int32_t l = 0; l < 32; ++l) {
-				lstart[l] = l * (l + 1) * (l + 2) / 6;
-			}
-			double poly_vgl_l1[4][4] = {{1.0, 0.0, 0.0, 0.0},
-										{0.0, 1.0, 0.0, 0.0},
-										{0.0, 0.0, 1.0, 0.0},
-										{0.0, 0.0, 0.0, 1.0}};
-			double poly_vgl_l2[5][10] = {
-				{1., 0., 0., 0., 0., 0., 0., 0., 0., 0.},
-				{0., 1., 0., 0., 0., 0., 0., 0., 0., 0.},
-				{0., 0., 1., 0., 0., 0., 0., 0., 0., 0.},
-				{0., 0., 0., 1., 0., 0., 0., 0., 0., 0.},
-				{0., 0., 0., 0., 2., 0., 0., 2., 0., 2.}};
-
-			const double e_coord[3] = {coord[ipoint], coord[ipoint + point_num],
-									   coord[ipoint + 2 * point_num]};
-
-			for (int64_t inucl = 0; inucl < nucl_num; ++inucl) {
-				const double n_coord[3] = {nucl_coord[inucl],
-										   nucl_coord[inucl + nucl_num],
-										   nucl_coord[inucl + 2 * nucl_num]};
-
-				// Test if the point is in the range of the
-				// nucleus
-				const double x = e_coord[0] - n_coord[0];
-				const double y = e_coord[1] - n_coord[1];
-				const double z = e_coord[2] - n_coord[2];
-
-				const double r2 = x * x + y * y + z * z;
+				r2 = x * x + y * y + z * z;
 
 				if (r2 > cutoff * nucleus_range[inucl]) {
 					continue;
 				}
 
-				int64_t n_poly;
-				switch (nucleus_max_ang_mom[inucl]) {
-				case 0:
-					break;
+				// C is zero-based, so shift bounds by one
+				ishell_start = nucleus_index[inucl] + 1;
+				ishell_end = nucleus_index[inucl] + nucleus_shell_num[inucl];
 
-				case 1:
-					poly_vgl_l1[0][1] = x;
-					poly_vgl_l1[0][2] = y;
-					poly_vgl_l1[0][3] = z;
-					break;
+				for (int ishell = ishell_start; ishell < ishell_end; ishell++) {
 
-				case 2:
-					poly_vgl_l2[0][1] = x;
-					poly_vgl_l2[0][2] = y;
-					poly_vgl_l2[0][3] = z;
-					poly_vgl_l2[0][4] = x * x;
-					poly_vgl_l2[0][5] = x * y;
-					poly_vgl_l2[0][6] = x * z;
-					poly_vgl_l2[0][7] = y * y;
-					poly_vgl_l2[0][8] = y * z;
-					poly_vgl_l2[0][9] = z * z;
-					poly_vgl_l2[1][4] = x + x;
-					poly_vgl_l2[1][5] = y;
-					poly_vgl_l2[1][6] = z;
-					poly_vgl_l2[2][5] = x;
-					poly_vgl_l2[2][7] = y + y;
-					poly_vgl_l2[2][8] = z;
-					poly_vgl_l2[3][6] = x;
-					poly_vgl_l2[3][8] = y;
-					poly_vgl_l2[3][9] = z + z;
-					break;
+					shell_vgl[ishell, 1, ipoint] = 0;
+					shell_vgl[ishell, 2, ipoint] = 0;
+					shell_vgl[ishell, 3, ipoint] = 0;
+					shell_vgl[ishell, 4, ipoint] = 0;
+					shell_vgl[ishell, 5, ipoint] = 0;
 
-				default:
+					iprim_start = shell_prim_index[ishell] + 1;
+					iprim_end =
+						shell_prim_index[ishell] + shell_prim_num[ishell];
 
-					qmckl_ao_polynomial_transp_vgl_hpc_device(
-						context, e_coord, n_coord, nucleus_max_ang_mom[inucl],
-						&n_poly, (int64_t)3, poly_vgl, size_max);
+					for (int iprim = iprim_start; iprim < iprim_end; iprim++) {
 
-					break;
-				}
-
-				// Compute all exponents
-				int64_t nidx = 0;
-				int base_idx = inucl * expo_per_nucleus_size_0;
-
-				for (int64_t iprim = 0; iprim < prim_num_per_nucleus[inucl];
-					 ++iprim) {
-					const double v =
-						expo_per_nucleus_data[base_idx + iprim] * r2;
-					if (v <= cutoff) {
-						++nidx;
-					} else {
-						break;
-					}
-				}
-
-				const int64_t ishell_start = nucleus_index[inucl];
-				const int64_t ishell_end =
-					nucleus_index[inucl] + nucleus_shell_num[inucl];
-
-				double ce_mat_0 = 0.;
-				double ce_mat_1 = 0.;
-				double ce_mat_2 = 0.;
-				double ce_mat_3 = 0.;
-				double ce_mat_4 = 0.;
-
-				double exp_mat_0 = 0.;
-				double exp_mat_1 = 0.;
-				double exp_mat_2 = 0.;
-				double exp_mat_3 = 0.;
-				double exp_mat_4 = 0.;
-
-				for (int64_t ishell = ishell_start; ishell < ishell_end;
-					 ++ishell) {
-					ce_mat_0 = 0.;
-					ce_mat_1 = 0.;
-					ce_mat_2 = 0.;
-					ce_mat_3 = 0.;
-					ce_mat_4 = 0.;
-
-					for (int k = 0; k < nidx; ++k) {
-						exp_mat_0 =
-							exp(-(expo_per_nucleus_data[base_idx + k] * r2));
-						double f =
-							expo_per_nucleus_data[base_idx + k] * exp_mat_0;
-						f = -f - f;
-						exp_mat_1 = f * x;
-						exp_mat_2 = f * y;
-						exp_mat_3 = f * z;
-						exp_mat_4 =
-							f *
-							(3.0 -
-							 2.0 * (expo_per_nucleus_data[base_idx + k] * r2));
-						if (coef_mat[inucl * shell_max * prim_max +
-									 (ishell - ishell_start) * prim_max + k] !=
-							0.) {
-							ce_mat_0 +=
-								coef_mat[inucl * shell_max * prim_max +
-										 (ishell - ishell_start) * prim_max +
-										 k] *
-								exp_mat_0;
-							ce_mat_1 +=
-								coef_mat[inucl * shell_max * prim_max +
-										 (ishell - ishell_start) * prim_max +
-										 k] *
-								exp_mat_1;
-							ce_mat_2 +=
-								coef_mat[inucl * shell_max * prim_max +
-										 (ishell - ishell_start) * prim_max +
-										 k] *
-								exp_mat_2;
-							ce_mat_3 +=
-								coef_mat[inucl * shell_max * prim_max +
-										 (ishell - ishell_start) * prim_max +
-										 k] *
-								exp_mat_3;
-							ce_mat_4 +=
-								coef_mat[inucl * shell_max * prim_max +
-										 (ishell - ishell_start) * prim_max +
-										 k] *
-								exp_mat_4;
+						ar2 = expo[iprim] * r2;
+						if (ar2 > cutoff) {
+							continue;
 						}
-					}
 
-					const double s1 = ce_mat_0;
-					if (s1 == 0.0)
-						continue;
-					const double s2 = ce_mat_1;
-					const double s3 = ce_mat_2;
-					const double s4 = ce_mat_3;
-					const double s5 = ce_mat_4;
+						v = coef_normalized[iprim] * exp(-ar2);
+						two_a = -2 * expo[iprim] * v;
 
-					const int64_t k = ao_index[ishell];
-					double *restrict const ao_vgl_1 =
-						ao_vgl + ipoint * 5 * ao_num + k;
+						shell_vgl[ishell + 0 * shell_num +
+								  ipoint * shell_num * 5] =
+							shell_vgl[ishell + 0 * shell_num +
+									  ipoint * shell_num * 5] +
+							v;
 
-					const int32_t l = shell_ang_mom[ishell];
-					const int32_t n = lstart[l + 1] - lstart[l];
+						shell_vgl[ishell + 1 * shell_num +
+								  ipoint * shell_num * 5] =
+							shell_vgl[ishell + 1 * shell_num +
+									  ipoint * shell_num * 5] +
+							two_a * x;
 
-					double *restrict const ao_vgl_2 = ao_vgl_1 + ao_num;
-					double *restrict const ao_vgl_3 = ao_vgl_1 + (ao_num << 1);
-					double *restrict const ao_vgl_4 =
-						ao_vgl_1 + (ao_num << 1) + ao_num;
-					double *restrict const ao_vgl_5 = ao_vgl_1 + (ao_num << 2);
+						shell_vgl[ishell + 2 * shell_num +
+								  ipoint * shell_num * 5] =
+							shell_vgl[ishell + 2 * shell_num +
+									  ipoint * shell_num * 5] +
+							two_a * y;
 
-					double *restrict poly_vgl_1 = NULL;
-					double *restrict poly_vgl_2 = NULL;
-					double *restrict poly_vgl_3 = NULL;
-					double *restrict poly_vgl_4 = NULL;
-					double *restrict poly_vgl_5 = NULL;
+						shell_vgl[ishell + 3 * shell_num +
+								  ipoint * shell_num * 5] =
+							shell_vgl[ishell + 3 * shell_num +
+									  ipoint * shell_num * 5] +
+							two_a * z;
 
-					if (nidx > 0) {
-						// printf("k=%ld\n", k);
-						const double *restrict f = ao_factor + k;
-						const int64_t idx = lstart[l];
-
-						switch (nucleus_max_ang_mom[inucl]) {
-						case 0:
-							break;
-						case 1:
-							poly_vgl_1 = &(poly_vgl_l1[0][idx]);
-							poly_vgl_2 = &(poly_vgl_l1[1][idx]);
-							poly_vgl_3 = &(poly_vgl_l1[2][idx]);
-							poly_vgl_4 = &(poly_vgl_l1[3][idx]);
-							break;
-						case 2:
-							poly_vgl_1 = &(poly_vgl_l2[0][idx]);
-							poly_vgl_2 = &(poly_vgl_l2[1][idx]);
-							poly_vgl_3 = &(poly_vgl_l2[2][idx]);
-							poly_vgl_4 = &(poly_vgl_l2[3][idx]);
-							poly_vgl_5 = &(poly_vgl_l2[4][idx]);
-							break;
-						default:
-							poly_vgl_1 = &(poly_vgl[idx]);
-							poly_vgl_2 = &(poly_vgl[size_max + idx]);
-							poly_vgl_3 = &(poly_vgl[2 * size_max + idx]);
-							poly_vgl_4 = &(poly_vgl[3 * size_max + idx]);
-							poly_vgl_5 = &(poly_vgl[4 * size_max + idx]);
-						}
-						switch (n) {
-						case (1):
-							// printf("0\n");
-							// printf("s1=%lf\n",
-							// s1);
-							// printf("ao_vgl_1[0]=%lf\n",
-							// ao_vgl_1[0]);
-							// printf("f[0]=%lf\n",
-							// f[0]); printf("1\n");
-							ao_vgl_1[0] = s1 * f[0];
-							// printf("2\n");
-							ao_vgl_2[0] = s2 * f[0];
-							ao_vgl_3[0] = s3 * f[0];
-							ao_vgl_4[0] = s4 * f[0];
-							ao_vgl_5[0] = s5;
-							break;
-						case (3):
-							for (int il = 0; il < 3; ++il) {
-								ao_vgl_1[il] = poly_vgl_1[il] * s1 * f[il];
-								ao_vgl_2[il] = (poly_vgl_2[il] * s1 +
-												poly_vgl_1[il] * s2) *
-											   f[il];
-								ao_vgl_3[il] = (poly_vgl_3[il] * s1 +
-												poly_vgl_1[il] * s3) *
-											   f[il];
-								ao_vgl_4[il] = (poly_vgl_4[il] * s1 +
-												poly_vgl_1[il] * s4) *
-											   f[il];
-								ao_vgl_5[il] = (poly_vgl_1[il] * s5 +
-												2.0 * (poly_vgl_2[il] * s2 +
-													   poly_vgl_3[il] * s3 +
-													   poly_vgl_4[il] * s4)) *
-											   f[il];
-							}
-							break;
-						case (6):
-							for (int il = 0; il < 6; ++il) {
-								ao_vgl_1[il] = poly_vgl_1[il] * s1 * f[il];
-								ao_vgl_2[il] = (poly_vgl_2[il] * s1 +
-												poly_vgl_1[il] * s2) *
-											   f[il];
-								ao_vgl_3[il] = (poly_vgl_3[il] * s1 +
-												poly_vgl_1[il] * s3) *
-											   f[il];
-								ao_vgl_4[il] = (poly_vgl_4[il] * s1 +
-												poly_vgl_1[il] * s4) *
-											   f[il];
-								ao_vgl_5[il] =
-									(poly_vgl_5[il] * s1 + poly_vgl_1[il] * s5 +
-									 2.0 * (poly_vgl_2[il] * s2 +
-											poly_vgl_3[il] * s3 +
-											poly_vgl_4[il] * s4)) *
-									f[il];
-							}
-							break;
-						default:
-							for (int il = 0; il < n; ++il) {
-								ao_vgl_1[il] = poly_vgl_1[il] * s1 * f[il];
-								ao_vgl_2[il] = (poly_vgl_2[il] * s1 +
-												poly_vgl_1[il] * s2) *
-											   f[il];
-								ao_vgl_3[il] = (poly_vgl_3[il] * s1 +
-												poly_vgl_1[il] * s3) *
-											   f[il];
-								ao_vgl_4[il] = (poly_vgl_4[il] * s1 +
-												poly_vgl_1[il] * s4) *
-											   f[il];
-								ao_vgl_5[il] =
-									(poly_vgl_5[il] * s1 + poly_vgl_1[il] * s5 +
-									 2.0 * (poly_vgl_2[il] * s2 +
-											poly_vgl_3[il] * s3 +
-											poly_vgl_4[il] * s4)) *
-									f[il];
-							}
-							break;
-						}
-					} else {
-						for (int64_t il = 0; il < n; ++il) {
-							ao_vgl_1[il] = 0.0;
-							ao_vgl_2[il] = 0.0;
-							ao_vgl_3[il] = 0.0;
-							ao_vgl_4[il] = 0.0;
-							ao_vgl_5[il] = 0.0;
-						}
+						shell_vgl[ishell + 4 * shell_num +
+								  ipoint * shell_num * 5] =
+							shell_vgl[ishell + 4 * shell_num +
+									  ipoint * shell_num * 5] +
+							two_a * (3 - 2 * ar2);
 					}
 				}
 			}
 		}
 	}
-	// End of target region
+}
 
+/* ao_vgl_gaussian */
+
+qmckl_exit_code qmckl_compute_ao_vgl_gaussian_device(
+	const qmckl_context context, const int64_t ao_num, const int64_t shell_num,
+	const int32_t *restrict prim_num_per_nucleus, const int64_t point_num,
+	const int64_t nucl_num, const double *restrict coord,
+	const double *restrict nucl_coord, const int64_t *restrict nucleus_index,
+	const int64_t *restrict nucleus_shell_num, const double *nucleus_range,
+	const int32_t *restrict nucleus_max_ang_mom,
+	const int32_t *restrict shell_ang_mom, const double *restrict ao_factor,
+	double *shell_vgl, double *restrict const ao_vgl) {
+
+	double *e_coord, *n_coord;
+	int64_t n_poly;
+	int64_t l, il, k;
+	int64_t ipoint, inucl, ishell;
+	int64_t ishell_start, ishell_end;
+	int64_t *lstart;
+	double x, y, z, r2;
+	double cutoff;
+	int64_t qmckl_ao_polynomial_vgl_doc_f;
+	int64_t size_max = 0;
+
+	double *poly_vgl;
+	int64_t *powers;
+	int64_t *ao_index;
+
+	qmckl_exit_code rc;
+	int lmax, c;
+
+	int device_id = qmckl_get_device_id(context);
+
+	lstart = omp_target_alloc(sizeof(int64_t) * 21, device_id);
+
+	e_coord = omp_target_alloc(sizeof(double) * 8, device_id);
+	n_coord = omp_target_alloc(sizeof(double) * 8, device_id);
+
+	poly_vgl = omp_target_alloc(sizeof(double) * 5 * ao_num, device_id);
+	powers = omp_target_alloc(sizeof(int64_t) * 3 * ao_num, device_id);
+	ao_index = omp_target_alloc(sizeof(int64_t) * ao_num, device_id);
+
+	// Specific calling function
+	lmax = -1;
+#pragma is_device_ptr(nucleus_max_ang_mom)
+	{
+#pragma omp target
+		{
+			for (int i = 0; i < nucl_num; i++) {
+				if (lmax < nucleus_max_ang_mom[i]) {
+					lmax = nucleus_max_ang_mom[i];
+				}
+			}
+		}
+	}
+	double *pows = omp_target_alloc(3 * (lmax + 2) * sizeof(double), device_id);
+
+#pragma omp target is_device_ptr(lstart)
+	{
+		for (l = 0; l < 21; l++) {
+			lstart[l] = l * (l + 1) * (l + 2) / 6 + 1;
+		}
+	}
+
+	k = 0;
+#pragma omp target is_device_ptr(nucleus_index, nucleus_shell_num,             \
+								 shell_ang_mom, ao_index, lstart)
+	{
+		for (inucl = 0; inucl < nucl_num; inucl++) {
+			ishell_start = nucleus_index[inucl] + 1;
+			ishell_end = nucleus_index[inucl] + nucleus_shell_num[inucl];
+			for (ishell = ishell_start; ishell < ishell_end; ishell++) {
+				l = shell_ang_mom[ishell];
+				ao_index[ishell] = k;
+				k = k + lstart[l + 1] - lstart[l];
+			}
+		}
+	}
+
+#pragma omp target is_device_ptr(                                              \
+	ao_vgl, lstart, e_coord, n_coord, ao_index, ao_factor, coord,              \
+	nucleus_max_ang_mom, nucleus_index, nucleus_shell_num, shell_vgl,          \
+	poly_vgl, nucl_coord, pows, powers, shell_ang_mom)
+	{
+#pragma omp teams distribute parallel for
+		for (ipoint = 0; ipoint < point_num; ipoint++) {
+
+			e_coord[0] = coord[0 * point_num + ipoint];
+			e_coord[1] = coord[1 * point_num + ipoint];
+			e_coord[2] = coord[2 * point_num + ipoint];
+
+			for (inucl = 0; inucl < nucl_num; inucl++) {
+
+				n_coord[0] = nucl_coord[0 * nucl_num + inucl];
+				n_coord[1] = nucl_coord[1 * nucl_num + inucl];
+				n_coord[2] = nucl_coord[2 * nucl_num + inucl];
+
+				x = e_coord[0] - n_coord[0];
+				y = e_coord[1] - n_coord[1];
+				z = e_coord[2] - n_coord[2];
+
+				r2 = x * x + y * y + z * z;
+
+				/* Beginning of ao_polynomial computation (now inlined)*/
+				double Y1, Y2, Y3;
+				double xy, yz, xz;
+				int c;
+				double da, db, dc, dd;
+
+				Y1 = e_coord[0] - n_coord[0];
+				Y2 = e_coord[1] - n_coord[1];
+				Y3 = e_coord[2] - n_coord[2];
+
+				if (nucleus_max_ang_mom[inucl] == 0) {
+
+					poly_vgl[0] = 1;
+					poly_vgl[1 * 3 + 0] = 0;
+					poly_vgl[2 * 3 + 0] = 0;
+					poly_vgl[3 * 3 + 0] = 0;
+					poly_vgl[4 * 3 + 0] = 0;
+
+					for (int i = 0; i < 3; i++) {
+						powers[0 * 3 + i] = 0;
+					}
+
+					n_poly = 0;
+
+				} else if (nucleus_max_ang_mom[inucl] > 0) {
+					for (int i = 0; i < 3; i++) {
+						for (int j = 0; j < 3; j++) {
+							pows[i * (nucleus_max_ang_mom[inucl] + 2) + j] = 1;
+						}
+					}
+
+					for (int i = 3; i < nucleus_max_ang_mom[inucl] + 2; i++) {
+						pows[0 * (nucleus_max_ang_mom[inucl] + 2) + i] =
+							pows[0 * (nucleus_max_ang_mom[inucl] + 2) +
+								 (i - 1)] *
+							Y1;
+						pows[1 * (nucleus_max_ang_mom[inucl] + 2) + i] =
+							pows[1 * (nucleus_max_ang_mom[inucl] + 2) +
+								 (i - 1)] *
+							Y2;
+						pows[2 * (nucleus_max_ang_mom[inucl] + 2) + i] =
+							pows[2 * (nucleus_max_ang_mom[inucl] + 2) +
+								 (i - 1)] *
+							Y3;
+					}
+
+					for (int i = 0; i < 5; i++) {
+						for (int j = 0; j < 4; j++) {
+							poly_vgl[i * 3 + j] = 0;
+						}
+					}
+					for (int i = 0; i < 3; i++) {
+						for (int j = 0; j < 4; j++) {
+							powers[i * 3 + j] = 0;
+						}
+					}
+
+					poly_vgl[0] = 1;
+
+					powers[1] = 1;
+					poly_vgl[1] = pows[0];
+					poly_vgl[1 * 3 + 1] = 1;
+					poly_vgl[2 * 3 + 2] = 1;
+
+					n_poly = 4;
+				}
+				// l >= 2
+
+				dd = 2;
+				for (int d = 4; d < nucleus_max_ang_mom[inucl]; d++) {
+					da = dd;
+					for (int a = d; a > 1; a--) {
+						db = dd - da;
+						for (int b = d - a; b > 1; b--) {
+
+							c = d - a - b;
+							dc = dd - da - db;
+							n_poly++;
+
+							powers[n_poly * 3 + 0] = a;
+							powers[n_poly * 3 + 1] = b;
+							powers[n_poly * 3 + 2] = c;
+
+							xy = pows[a] *
+								 pows[1 * (nucleus_max_ang_mom[inucl] + 2) + b];
+							yz =
+								pows[1 * (nucleus_max_ang_mom[inucl] + 2) + b] *
+								pows[2 * (nucleus_max_ang_mom[inucl] + 2) + c];
+							yz = pows[a] *
+								 pows[2 * (nucleus_max_ang_mom[inucl] + 2) + c];
+
+							poly_vgl[n_poly * ao_num + 0] =
+								xy *
+								powers[3 * (nucleus_max_ang_mom[inucl] + 2) +
+									   2];
+
+							xy = dc * xy;
+							xz = db * xz;
+							yz = da * yz;
+
+							poly_vgl[n_poly * 5 + 1] =
+								pows[0 * (nucleus_max_ang_mom[inucl] + 2) + a -
+									 1] *
+								yz;
+							poly_vgl[n_poly * 5 + 2] =
+								pows[1 * (nucleus_max_ang_mom[inucl] + 2) +
+									 (b - 1)] *
+								xz;
+							poly_vgl[n_poly * 5 + 3] =
+								pows[2 * (nucleus_max_ang_mom[inucl] + 2) +
+									 (c - 1)] *
+								xy;
+
+							poly_vgl[n_poly * ao_num + 4] =
+								(da - 1) * pows[a - 2] * yz +
+								(db - 1) *
+									pows[1 * (nucleus_max_ang_mom[inucl] + 2) +
+										 (b - 2)] *
+									xz +
+								(dc - 1) *
+									pows[2 * (nucleus_max_ang_mom[inucl] + 2) +
+										 (c - 2)] *
+									xy;
+
+							db = db - 1;
+						}
+						da = da - 1;
+					}
+					dd = dd + 1;
+				}
+				/* End of ao_polynomial computation (now inlined)*/
+
+				ishell_start = nucleus_index[inucl] + 1;
+				ishell_end = nucleus_index[inucl] + nucleus_shell_num[inucl];
+
+				for (ishell = ishell_start; ishell < ishell_end; ishell++) {
+					k = ao_index[ishell];
+					l = shell_ang_mom[ishell];
+					for (il = lstart[l]; il < lstart[l + 1]; il++) {
+						// value
+						ao_vgl[ipoint * 5 * ao_num + 0 * ao_num + k] =
+							poly_vgl[il * 5 + 0] *
+							shell_vgl[ipoint * 5 * shell_num + 0 * shell_num +
+									  ishell] *
+							ao_factor[k];
+
+						// Grad x
+						ao_vgl[ipoint * 5 * ao_num + 1 * ao_num + k] =
+							poly_vgl[il * 5 + 0] *
+								shell_vgl[ipoint * 5 * shell_num +
+										  0 * shell_num + ishell] +
+							poly_vgl[il * 5 + 1] *
+								shell_vgl[ipoint * 5 * shell_num +
+										  1 * shell_num + ishell] *
+								ao_factor[k];
+
+						// grad y
+						ao_vgl[ipoint * 5 * ao_num + 2 * ao_num + k] =
+							poly_vgl[il * 5 + 2] *
+								shell_vgl[ipoint * 5 * shell_num +
+										  0 * shell_num + ishell] +
+							poly_vgl[il * 5 + 1] *
+								shell_vgl[ipoint * 5 * shell_num +
+										  2 * shell_num + ishell] *
+								ao_factor[k];
+
+						// grad z
+						ao_vgl[ipoint * 5 * ao_num + 3 * ao_num + k] =
+							poly_vgl[il * 5 + 3] *
+								shell_vgl[ipoint * 5 * shell_num +
+										  0 * shell_num + ishell] +
+							poly_vgl[il * 5 + 1] *
+								shell_vgl[ipoint * 5 * shell_num +
+										  3 * shell_num + ishell] *
+								ao_factor[k];
+
+						// Lapl_z
+
+						ao_vgl[ipoint * 5 * ao_num + 4 * ao_num + k] =
+							(poly_vgl[il * 5 + 4] *
+								 shell_vgl[ipoint * 5 * shell_num +
+										   0 * shell_num + ishell] +
+							 poly_vgl[il * 5 + 0] *
+								 shell_vgl[ipoint * 5 * shell_num +
+										   0 * shell_num + ishell] +
+							 2.0 * (poly_vgl[il * 5 + 1] *
+										shell_vgl[ipoint * 5 * shell_num +
+												  1 * shell_num + ishell] +
+									poly_vgl[il * 5 + 2] *
+										shell_vgl[ipoint * 5 * shell_num +
+												  2 * shell_num + ishell] +
+									poly_vgl[il * 5 + 3] *
+										shell_vgl[ipoint * 5 * shell_num +
+												  3 * shell_num + ishell])) *
+							ao_factor[k];
+
+						k = k + 1;
+					}
+				}
+			}
+		}
+	}
+
+	omp_target_free(lstart, device_id);
+	omp_target_free(e_coord, device_id);
+	omp_target_free(n_coord, device_id);
+	omp_target_free(poly_vgl, device_id);
+	omp_target_free(powers, device_id);
 	omp_target_free(ao_index, device_id);
-	omp_target_free(coef_mat, device_id);
-	omp_target_free(poly_vgl_shared, device_id);
-	omp_target_free(lstart_h, device_id);
+
+	omp_target_free(pows, device_id);
 
 	return QMCKL_SUCCESS;
 }
@@ -568,6 +426,70 @@ qmckl_exit_code qmckl_compute_ao_vgl_gaussian_device(
 //**********
 // PROVIDE
 //**********
+
+/* shell_vgl */
+
+qmckl_exit_code
+qmckl_provide_ao_basis_shell_vgl_device(qmckl_context_device context) {
+
+	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
+		return qmckl_failwith(context, QMCKL_INVALID_CONTEXT,
+							  "qmckl_provide_ao_basis_ao_vgl_device", NULL);
+	}
+
+	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
+	assert(ctx != NULL);
+
+	if (!ctx->ao_basis.provided) {
+		return qmckl_failwith(context, QMCKL_NOT_PROVIDED,
+							  "qmckl_provide_ao_basis_shell_vgl_device", NULL);
+	}
+
+	/* Compute if necessary */
+	if (ctx->point.date > ctx->ao_basis.shell_vgl_date) {
+
+		/* Allocate array */
+		if (ctx->ao_basis.shell_vgl == NULL) {
+
+			qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
+			mem_info.size =
+				ctx->ao_basis.shell_num * 5 * ctx->point.num * sizeof(double);
+			double *shell_vgl =
+				(double *)qmckl_malloc_device(context, mem_info);
+
+			if (shell_vgl == NULL) {
+				return qmckl_failwith(context, QMCKL_ALLOCATION_FAILED,
+									  "qmckl_ao_basis_shell_vgl_device", NULL);
+			}
+			ctx->ao_basis.shell_vgl = shell_vgl;
+		}
+
+		qmckl_exit_code rc;
+		if (ctx->ao_basis.type == 'G') {
+			rc = qmckl_compute_ao_basis_shell_gaussian_vgl_device(
+				context, ctx->ao_basis.prim_num, ctx->ao_basis.shell_num,
+				ctx->point.num, ctx->nucleus.num,
+				ctx->ao_basis.nucleus_shell_num, ctx->ao_basis.nucleus_index,
+				ctx->ao_basis.nucleus_range, ctx->ao_basis.shell_prim_index,
+				ctx->ao_basis.shell_prim_num, ctx->point.coord.data,
+				ctx->nucleus.coord.data, ctx->ao_basis.exponent,
+				ctx->ao_basis.coefficient_normalized, ctx->ao_basis.shell_vgl);
+		} else {
+			return qmckl_failwith(context, QMCKL_FAILURE,
+								  "compute_ao_basis_shell_vgl",
+								  "Not yet implemented for basis type != 'G'");
+		}
+		if (rc != QMCKL_SUCCESS) {
+			return rc;
+		}
+
+		ctx->ao_basis.shell_vgl_date = ctx->date;
+	}
+
+	return QMCKL_SUCCESS;
+}
+
+/* ao_vgl_gaussian */
 
 qmckl_exit_code
 qmckl_provide_ao_basis_ao_vgl_device(qmckl_context_device context) {
@@ -605,7 +527,57 @@ qmckl_provide_ao_basis_ao_vgl_device(qmckl_context_device context) {
 			ctx->ao_basis.ao_vgl = ao_vgl;
 		}
 
+		/* Checking for shell_vgl */
+		if (ctx->ao_basis.shell_vgl == NULL ||
+			ctx->point.date > ctx->ao_basis.shell_vgl_date) {
+
+			/* Free if not NULL */
+			if (ctx->ao_basis.shell_vgl != NULL) {
+				qmckl_free_device(context, ctx->ao_basis.shell_vgl);
+			}
+
+			/* (Re) Alloc */
+			qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
+			mem_info.size =
+				ctx->ao_basis.shell_num * 5 * ctx->point.num * sizeof(double);
+			double *shell_vgl =
+				(double *)qmckl_malloc_device(context, mem_info);
+
+			if (shell_vgl == NULL) {
+				return qmckl_failwith(context, QMCKL_ALLOCATION_FAILED,
+									  "qmckl_ao_basis_shell_vgl", NULL);
+			}
+
+			ctx->ao_basis.shell_vgl = shell_vgl;
+
+			/* Compute*/
+			if (ctx->ao_basis.type == 'G') {
+				rc = qmckl_compute_ao_basis_shell_gaussian_vgl_device(
+					context, ctx->ao_basis.prim_num, ctx->ao_basis.shell_num,
+					ctx->point.num, ctx->nucleus.num,
+					ctx->ao_basis.nucleus_shell_num,
+					ctx->ao_basis.nucleus_index, ctx->ao_basis.nucleus_range,
+					ctx->ao_basis.shell_prim_index,
+					ctx->ao_basis.shell_prim_num, ctx->point.coord.data,
+					ctx->nucleus.coord.data, ctx->ao_basis.exponent,
+					ctx->ao_basis.coefficient_normalized,
+					ctx->ao_basis.shell_vgl);
+			} else {
+				return qmckl_failwith(context, QMCKL_FAILURE,
+									  "compute_ao_basis_shell_vgl",
+									  "Not yet implemented");
+			}
+			if (rc != QMCKL_SUCCESS) {
+				return rc;
+			}
+
+			ctx->ao_basis.shell_vgl_date = ctx->date;
+
+			ctx->ao_basis.shell_vgl = shell_vgl;
+		}
+
 		if (ctx->ao_basis.type == 'G') {
+#pragma omp is_device_ptr(coord_device)
 			rc = qmckl_compute_ao_vgl_gaussian_device(
 				context, ctx->ao_basis.ao_num, ctx->ao_basis.shell_num,
 				ctx->ao_basis.prim_num_per_nucleus, ctx->point.num,
@@ -613,8 +585,8 @@ qmckl_provide_ao_basis_ao_vgl_device(qmckl_context_device context) {
 				ctx->nucleus.coord.data, ctx->ao_basis.nucleus_index,
 				ctx->ao_basis.nucleus_shell_num, ctx->ao_basis.nucleus_range,
 				ctx->ao_basis.nucleus_max_ang_mom, ctx->ao_basis.shell_ang_mom,
-				ctx->ao_basis.ao_factor, ctx->ao_basis.expo_per_nucleus,
-				ctx->ao_basis.coef_per_nucleus, ctx->ao_basis.ao_vgl);
+				ctx->ao_basis.ao_factor, ctx->ao_basis.shell_vgl,
+				ctx->ao_basis.ao_vgl);
 		} else {
 			printf("Device pointers version of ao_vgl only "
 				   "supports 'G' as its "
@@ -634,6 +606,41 @@ qmckl_provide_ao_basis_ao_vgl_device(qmckl_context_device context) {
 //**********
 // GET
 //**********
+
+/* shell_vgl */
+
+qmckl_exit_code
+qmckl_get_ao_basis_shell_vgl_device(qmckl_context_device context,
+									double *const shell_vgl,
+									const int64_t size_max) {
+	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
+		return qmckl_failwith(context, QMCKL_INVALID_CONTEXT,
+							  "qmckl_get_ao_basis_shell_vgl_device", NULL);
+	}
+
+	qmckl_exit_code rc;
+
+	rc = qmckl_provide_ao_basis_shell_vgl_device(context);
+	if (rc != QMCKL_SUCCESS)
+		return rc;
+
+	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
+	assert(ctx != NULL);
+	// int device_id = qmckl_get_device_id(context);
+
+	int64_t sze = ctx->ao_basis.shell_num * 5 * ctx->point.num;
+	if (size_max < sze) {
+		return qmckl_failwith(context, QMCKL_INVALID_ARG_3,
+							  "qmckl_get_ao_basis_shell_vgl",
+							  "input array too small");
+	}
+	qmckl_memcpy_D2D(context, shell_vgl, ctx->ao_basis.shell_vgl,
+					 (size_t)sze * sizeof(double));
+
+	return QMCKL_SUCCESS;
+}
+
+/* ao_vgl_gaussian */
 
 qmckl_exit_code qmckl_get_ao_basis_ao_vgl_device(qmckl_context_device context,
 												 double *const ao_vgl,

--- a/src/qmckl_blas_omp_device.c
+++ b/src/qmckl_blas_omp_device.c
@@ -152,7 +152,7 @@ qmckl_matrix_of_double_device(const qmckl_context_device context,
 							  "Matrix not allocated");
 	}
 
-	if (matrix.size[0] * matrix.size[1] != size_max) {
+	if (matrix.size[0] * matrix.size[1] > size_max) {
 		return qmckl_failwith(context, QMCKL_INVALID_ARG_4,
 							  "qmckl_matrix_of_double_device",
 							  "Wrong vector size");

--- a/src/qmckl_blas_omp_device.c
+++ b/src/qmckl_blas_omp_device.c
@@ -1,15 +1,16 @@
 #include "../include/qmckl_blas_device.h"
 #include <omp.h>
 
-// This file provides OpenMP implementations of BLAS functions (mostly initialization and
-// manipulation of vector, matrix, ... types). All functions accept device pointers.
+// This file provides OpenMP implementations of BLAS functions (mostly
+// initialization and manipulation of vector, matrix, ... types). All functions
+// accept device pointers.
 
 //**********
 // VECTOR
 //**********
 
 qmckl_vector qmckl_vector_alloc_device(qmckl_context_device context,
-										   const int64_t size) {
+									   const int64_t size) {
 	/* Should always be true by contruction */
 	assert(size > (int64_t)0);
 
@@ -28,7 +29,7 @@ qmckl_vector qmckl_vector_alloc_device(qmckl_context_device context,
 }
 
 qmckl_exit_code qmckl_vector_free_device(qmckl_context_device context,
-											 qmckl_vector *vector) {
+										 qmckl_vector *vector) {
 	/* Always true */
 	assert(vector->data != NULL);
 
@@ -46,8 +47,8 @@ qmckl_exit_code qmckl_vector_free_device(qmckl_context_device context,
 
 qmckl_exit_code
 qmckl_vector_of_double_device(const qmckl_context_device context,
-								  const double *target, const int64_t size_max,
-								  qmckl_vector *vector_out) {
+							  const double *target, const int64_t size_max,
+							  qmckl_vector *vector_out) {
 
 	int device_id = qmckl_get_device_id(context);
 
@@ -78,8 +79,8 @@ qmckl_vector_of_double_device(const qmckl_context_device context,
 //**********
 
 qmckl_matrix qmckl_matrix_alloc_device(qmckl_context_device context,
-										   const int64_t size1,
-										   const int64_t size2) {
+									   const int64_t size1,
+									   const int64_t size2) {
 	/* Should always be true by contruction */
 	assert(size1 * size2 > (int64_t)0);
 
@@ -90,8 +91,7 @@ qmckl_matrix qmckl_matrix_alloc_device(qmckl_context_device context,
 
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = size1 * size2 * sizeof(double);
-	result.data =
-		(double *)qmckl_malloc_device(context, mem_info);
+	result.data = (double *)qmckl_malloc_device(context, mem_info);
 
 	if (result.data == NULL) {
 		result.size[0] = (int64_t)0;
@@ -102,7 +102,7 @@ qmckl_matrix qmckl_matrix_alloc_device(qmckl_context_device context,
 }
 
 qmckl_exit_code qmckl_matrix_free_device(qmckl_context_device context,
-											 qmckl_matrix *matrix) {
+										 qmckl_matrix *matrix) {
 	/* Always true */
 	assert(matrix->data != NULL);
 
@@ -135,8 +135,8 @@ qmckl_matrix qmckl_matrix_set_device(qmckl_matrix matrix, double value) {
 
 qmckl_exit_code
 qmckl_matrix_of_double_device(const qmckl_context_device context,
-								  const double *target, const int64_t size_max,
-								  qmckl_matrix *matrix_out) {
+							  const double *target, const int64_t size_max,
+							  qmckl_matrix *matrix_out) {
 
 	// (assuming the matrix is already allocated)
 
@@ -166,16 +166,14 @@ qmckl_matrix_of_double_device(const qmckl_context_device context,
 }
 
 qmckl_exit_code qmckl_transpose_device(qmckl_context_device context,
-										   const qmckl_matrix A,
-										   qmckl_matrix At) {
+									   const qmckl_matrix A, qmckl_matrix At) {
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return QMCKL_INVALID_CONTEXT;
 	}
 
 	if (A.size[0] < 1) {
 		return qmckl_failwith(context, QMCKL_INVALID_ARG_2,
-							  "qmckl_transpose_device",
-							  "Invalid size for A");
+							  "qmckl_transpose_device", "Invalid size for A");
 	}
 
 	if (At.data == NULL) {
@@ -186,8 +184,7 @@ qmckl_exit_code qmckl_transpose_device(qmckl_context_device context,
 
 	if (At.size[0] != A.size[1] || At.size[1] != A.size[0]) {
 		return qmckl_failwith(context, QMCKL_INVALID_ARG_3,
-							  "qmckl_transpose_device",
-							  "Invalid size for At");
+							  "qmckl_transpose_device", "Invalid size for At");
 	}
 
 	double *A_data = A.data;
@@ -213,8 +210,8 @@ qmckl_exit_code qmckl_transpose_device(qmckl_context_device context,
 //**********
 
 qmckl_tensor qmckl_tensor_alloc_device(qmckl_context context,
-										   const int64_t order,
-										   const int64_t *size) {
+									   const int64_t order,
+									   const int64_t *size) {
 	/* Should always be true by construction */
 	assert(order > 0);
 	assert(order <= QMCKL_TENSOR_ORDER_MAX);
@@ -233,8 +230,7 @@ qmckl_tensor qmckl_tensor_alloc_device(qmckl_context context,
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = prod_size * sizeof(double);
 
-	result.data =
-		(double *)qmckl_malloc_device(context, mem_info);
+	result.data = (double *)qmckl_malloc_device(context, mem_info);
 
 	if (result.data == NULL) {
 		memset(&result, 0, sizeof(qmckl_tensor));
@@ -244,7 +240,7 @@ qmckl_tensor qmckl_tensor_alloc_device(qmckl_context context,
 }
 
 qmckl_exit_code qmckl_tensor_free_device(qmckl_context_device context,
-											 qmckl_tensor *tensor) {
+										 qmckl_tensor *tensor) {
 	/* Always true */
 	assert(tensor->data != NULL);
 

--- a/src/qmckl_blas_omp_device.c
+++ b/src/qmckl_blas_omp_device.c
@@ -1,7 +1,8 @@
 #include "../include/qmckl_blas_device.h"
 #include <omp.h>
 
-// NOTE Device versions of these functions will be added as they are needed
+// This file provides OpenMP implementations of BLAS functions (mostly initialization and
+// manipulation of vector, matrix, ... types). All functions accept device pointers.
 
 //**********
 // VECTOR
@@ -48,9 +49,6 @@ qmckl_vector_of_double_device(const qmckl_context_device context,
 								  const double *target, const int64_t size_max,
 								  qmckl_vector *vector_out) {
 
-	// Accepts an host array and copies it in the device section of
-	// vector_out (assuming the vector is already allocated)
-
 	int device_id = qmckl_get_device_id(context);
 
 	qmckl_vector vector = *vector_out;
@@ -69,7 +67,7 @@ qmckl_vector_of_double_device(const qmckl_context_device context,
 	}
 
 	omp_target_memcpy(vector.data, target, vector.size * sizeof(double), 0, 0,
-					  device_id, omp_get_initial_device());
+					  device_id, device_id);
 
 	*vector_out = vector;
 	return QMCKL_SUCCESS;
@@ -140,7 +138,6 @@ qmckl_matrix_of_double_device(const qmckl_context_device context,
 								  const double *target, const int64_t size_max,
 								  qmckl_matrix *matrix_out) {
 
-	// Accepts an host array and copies it in the device section of matrix
 	// (assuming the matrix is already allocated)
 
 	int device_id = qmckl_get_device_id(context);
@@ -162,7 +159,7 @@ qmckl_matrix_of_double_device(const qmckl_context_device context,
 	}
 
 	omp_target_memcpy(matrix.data, target, size_max * sizeof(double), 0, 0,
-					  device_id, omp_get_initial_device());
+					  device_id, device_id);
 
 	*matrix_out = matrix;
 	return QMCKL_SUCCESS;
@@ -218,7 +215,7 @@ qmckl_exit_code qmckl_transpose_device(qmckl_context_device context,
 qmckl_tensor qmckl_tensor_alloc_device(qmckl_context context,
 										   const int64_t order,
 										   const int64_t *size) {
-	/* Should always be true by contruction */
+	/* Should always be true by construction */
 	assert(order > 0);
 	assert(order <= QMCKL_TENSOR_ORDER_MAX);
 	assert(size != NULL);

--- a/src/qmckl_context_device.c
+++ b/src/qmckl_context_device.c
@@ -18,17 +18,16 @@ qmckl_exit_code qmckl_context_touch_device(const qmckl_context_device context) {
 // OpenMP/OpenACC dependent
 
 qmckl_context_device qmckl_context_create_device(int device_id) {
-	qmckl_context_device context =
-		(qmckl_context_device)qmckl_context_create();
+	qmckl_context_device context = (qmckl_context_device)qmckl_context_create();
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
-
-	qmckl_context_device_struct *const ds =
-		(qmckl_context_device_struct *)ctx->qmckl_extra;
 
 	/* Allocate the qmckl_context_device_struct */
 	ctx->qmckl_extra = malloc(sizeof(qmckl_context_device_struct));
 
-	/* Allocate qmckl_memory_struct */
+	qmckl_context_device_struct *const ds =
+		(qmckl_context_device_struct *)ctx->qmckl_extra;
+
+	/* Allocate the device qmckl_memory_struct */
 	const size_t size = 128L;
 	qmckl_memory_info_struct *new_array =
 		calloc(size, sizeof(qmckl_memory_info_struct));

--- a/src/qmckl_context_omp_device.c
+++ b/src/qmckl_context_omp_device.c
@@ -2,7 +2,6 @@
 
 // This file contains qmckl_context_device related functions
 
-
 //**********
 // CONTEXT DESTROY
 //**********

--- a/src/qmckl_memory_device.c
+++ b/src/qmckl_memory_device.c
@@ -1,7 +1,8 @@
 #include "../include/qmckl_memory_device.h"
 
-// This file contains functions to allocate host memory in a qmckl_context_device
-// (we will likely use these functions in exceptional cases only)
+// This file contains functions to allocate host memory in a
+// qmckl_context_device (we will likely use these functions in exceptional cases
+// only)
 
 //**********
 // HOST MEMORY

--- a/src/qmckl_trexio_device.c
+++ b/src/qmckl_trexio_device.c
@@ -1,7 +1,7 @@
 #include "../include/qmckl_trexio_device.h"
 
 // This file provides wrappers to standard QMCkl functions accessible with the
-// _device suffix
+// _device suffix. Only includes functions independent of OpenMP/OpenACC syntax.
 
 //**********
 // ELECTRON/POINT GETTERS/SETTERS

--- a/src/qmckl_trexio_omp_device.c
+++ b/src/qmckl_trexio_omp_device.c
@@ -209,7 +209,6 @@ qmckl_exit_code qmckl_set_nucleus_coord_device(qmckl_context_device context,
 											   const double *coord,
 											   const int64_t size_max) {
 	int32_t mask = 1 << 2;
-
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_NULL_CONTEXT,
 							  "qmckl_set_nucleus_coord_device", NULL);
@@ -227,10 +226,11 @@ qmckl_exit_code qmckl_set_nucleus_coord_device(qmckl_context_device context,
 	}
 
 	ctx->nucleus.coord = qmckl_matrix_alloc_device(context, nucl_num, 3);
+	double *nucleus_coord_data = ctx->nucleus.coord.data;
 
-#pragma use_device_ptr(ctx->nucleus.coord.data)
+#pragma use_device_ptr(nuleus_coord_data)
 	{
-		if (ctx->nucleus.coord.data == NULL) {
+		if (nucleus_coord_data == NULL) {
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED,
 								  "qmckl_set_nucleus_coord_device", NULL);
@@ -250,6 +250,7 @@ qmckl_exit_code qmckl_set_nucleus_coord_device(qmckl_context_device context,
 		if (rc != QMCKL_SUCCESS)
 			return rc;
 		rc = qmckl_transpose_device(context, At, ctx->nucleus.coord);
+		qmckl_matrix_free_device(context, &At);
 	} else {
 		rc = qmckl_matrix_of_double_device(context, coord, nucl_num * 3,
 										   &(ctx->nucleus.coord));
@@ -2019,7 +2020,6 @@ qmckl_exit_code
 qmckl_trexio_read_electron_X_device(qmckl_context_device context,
 									trexio_t *const file) {
 
-	printf("[qmckl_trexio_read_electron_X_device] In\n");
 	assert(context != (qmckl_context_device)0);
 	assert(file != NULL);
 
@@ -2048,13 +2048,11 @@ qmckl_trexio_read_electron_X_device(qmckl_context_device context,
 
 	qmckl_exit_code rc;
 	rc = qmckl_set_electron_num_device(context, up_num, dn_num);
-	printf("[qmckl_trexio_read_electron_X_device] Out\n");
 	return rc;
 }
 
 qmckl_exit_code qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
 												   trexio_t *const file) {
-	printf("[qmckl_trexio_read_nucleus_X_device] In\n");
 	assert(context != (qmckl_context)0);
 	assert(file != NULL);
 
@@ -2135,8 +2133,8 @@ qmckl_exit_code qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
 	}
 
 	qmckl_memcpy_H2D(context, nucl_coord_d, nucl_coord_h, mem_info.size);
-	rc = qmckl_set_nucleus_coord_device((qmckl_context)context, 'N',
-										nucl_coord_d, 3 * nucleus_num);
+	rc = qmckl_set_nucleus_coord_device(context, 'N', nucl_coord_d,
+										3 * nucleus_num);
 
 	qmckl_free_host(context, nucl_coord_h);
 	qmckl_free_device(context, nucl_coord_d);
@@ -2147,13 +2145,11 @@ qmckl_exit_code qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
 		return rc;
 	}
 
-	printf("[qmckl_trexio_read_nucleus_X_device] Out\n");
 	return QMCKL_SUCCESS;
 }
 
 qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 											  trexio_t *const file) {
-	printf("[qmckl_trexio_read_ao_X_device] In\n");
 	assert(context != (qmckl_context)0);
 	assert(file != NULL);
 
@@ -2168,7 +2164,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 #define MAX_STR_LEN 1024
 	char basis_type[MAX_STR_LEN];
 
-	printf("[qmckl_trexio_read_ao_X_device] 0\n");
 	rcio = trexio_read_basis_type(file, basis_type, MAX_STR_LEN);
 	if (rcio != TREXIO_SUCCESS) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
@@ -2188,7 +2183,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 
 	int64_t shell_num = 0L;
 
-	printf("[qmckl_trexio_read_ao_X_device] 1\n");
 	rcio = trexio_read_basis_shell_num_64(file, &shell_num);
 	if (rcio != TREXIO_SUCCESS) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
@@ -2219,7 +2213,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 
 	int64_t ao_num = 0LL;
 
-	printf("[qmckl_trexio_read_ao_X_device] 2\n");
 	rcio = trexio_read_ao_num_64(file, &ao_num);
 	if (rcio != TREXIO_SUCCESS) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
@@ -2233,7 +2226,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 	if (rc != QMCKL_SUCCESS)
 		return rc;
 
-	printf("[qmckl_trexio_read_ao_X_device] 3\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2334,7 +2326,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
-	printf("[qmckl_trexio_read_ao_X_device] 4\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2426,7 +2417,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
-	printf("[qmckl_trexio_read_ao_X_device] 5\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2476,7 +2466,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
-	printf("[qmckl_trexio_read_ao_X_device] 6\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2568,7 +2557,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
-	printf("[qmckl_trexio_read_ao_X_device] 7\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2655,7 +2643,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
-	printf("[qmckl_trexio_read_ao_X_device] 8\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2702,7 +2689,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
-	printf("[qmckl_trexio_read_ao_X_device] 9\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2745,7 +2731,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
-	printf("[qmckl_trexio_read_ao_X_device] 10\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2791,7 +2776,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
-	printf("[qmckl_trexio_read_ao_X_device] 11\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2837,7 +2821,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
-	printf("[qmckl_trexio_read_ao_X_device] 12\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2885,13 +2868,11 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
-	printf("[qmckl_trexio_ao_X_device] Out\n");
 	return QMCKL_SUCCESS;
 }
 
 qmckl_exit_code qmckl_trexio_read_mo_X_device(qmckl_context_device context,
 											  trexio_t *const file) {
-	printf("[qmckl_trexio_mo_X_device] In\n");
 	assert(context != (qmckl_context_device)0);
 	assert(file != NULL);
 
@@ -2952,14 +2933,12 @@ qmckl_exit_code qmckl_trexio_read_mo_X_device(qmckl_context_device context,
 			return rc;
 	}
 
-	printf("[qmckl_trexio_mo_X_device] Out\n");
 	return QMCKL_SUCCESS;
 }
 
 qmckl_exit_code qmckl_trexio_read_device(const qmckl_context_device context,
 										 const char *file_name,
 										 const int64_t size_max) {
-	printf("[qmckl_trexio_read_device] In\n");
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return false;
 	}
@@ -3011,6 +2990,5 @@ qmckl_exit_code qmckl_trexio_read_device(const qmckl_context_device context,
 
 	trexio_close(file);
 	file = NULL;
-	printf("[qmckl_trexio_read_device] Out\n");
 	return rc;
 }

--- a/src/qmckl_trexio_omp_device.c
+++ b/src/qmckl_trexio_omp_device.c
@@ -1,5 +1,11 @@
 #include "qmckl_trexio_device.h"
 
+// This file provides wrappers to standard QMCkl functions accessible with the
+// _device suffix. Includes OpenMP implementations.
+// All getters/setters work with device pointers. Except when initializing the
+// context from a TREXIO file, transferring data from/to the GPU must be handled
+// by the user.
+
 //**********
 // ELECTRON/POINT GETTERS/SETTERS
 //**********
@@ -166,9 +172,6 @@ qmckl_set_nucleus_charge_device(qmckl_context_device context,
 	}
 
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
-
-	// This accepts a host pointer and copies it in context as a device
-	// pointer
 
 	if (charge == NULL) {
 		return qmckl_failwith(context, QMCKL_INVALID_ARG_2,
@@ -1251,8 +1254,6 @@ qmckl_exit_code qmckl_set_ao_basis_nucleus_index_device(
 
 	int device_id = qmckl_get_device_id(context);
 
-	// Accepts an host array and copies it on device
-
 	int32_t mask = 1 << 4;
 
 	const int64_t nucl_num = ctx->nucleus.num;
@@ -1291,7 +1292,7 @@ qmckl_exit_code qmckl_set_ao_basis_nucleus_index_device(
 	}
 
 	omp_target_memcpy(new_array, nucleus_index, mem_info.size, 0, 0, device_id,
-					  omp_get_initial_device());
+					  device_id);
 
 	ctx->ao_basis.nucleus_index = new_array;
 
@@ -1319,8 +1320,6 @@ qmckl_exit_code qmckl_set_ao_basis_nucleus_shell_num_device(
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
 	int device_id = qmckl_get_device_id(context);
-
-	// Accepts an host device and copies it on device.
 
 	int32_t mask = 1 << 3;
 
@@ -1360,7 +1359,7 @@ qmckl_exit_code qmckl_set_ao_basis_nucleus_shell_num_device(
 	}
 
 	omp_target_memcpy(new_array, nucleus_shell_num, mem_info.size, 0, 0,
-					  device_id, omp_get_initial_device());
+					  device_id, device_id);
 
 	ctx->ao_basis.nucleus_shell_num = new_array;
 
@@ -1388,8 +1387,6 @@ qmckl_exit_code qmckl_set_ao_basis_shell_ang_mom_device(
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
 	int device_id = qmckl_get_device_id(context);
-
-	// Accepts an host array and copies it on device.
 
 	int32_t mask = 1 << 5;
 
@@ -1429,7 +1426,7 @@ qmckl_exit_code qmckl_set_ao_basis_shell_ang_mom_device(
 	}
 
 	omp_target_memcpy(new_array, shell_ang_mom, mem_info.size, 0, 0, device_id,
-					  omp_get_initial_device());
+					  device_id);
 
 	ctx->ao_basis.shell_ang_mom = new_array;
 
@@ -1457,8 +1454,6 @@ qmckl_exit_code qmckl_set_ao_basis_shell_prim_num_device(
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
 	int device_id = qmckl_get_device_id(context);
-
-	// Accepts an host array and copies it on device
 
 	int32_t mask = 1 << 6;
 
@@ -1498,7 +1493,7 @@ qmckl_exit_code qmckl_set_ao_basis_shell_prim_num_device(
 	}
 
 	omp_target_memcpy(new_array, shell_prim_num, mem_info.size, 0, 0, device_id,
-					  omp_get_initial_device());
+					  device_id);
 
 	ctx->ao_basis.shell_prim_num = new_array;
 
@@ -1526,8 +1521,6 @@ qmckl_exit_code qmckl_set_ao_basis_shell_prim_index_device(
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
 	int device_id = qmckl_get_device_id(context);
-
-	// Accepts an host array and copies it on device
 
 	int32_t mask = 1 << 7;
 
@@ -1567,7 +1560,7 @@ qmckl_exit_code qmckl_set_ao_basis_shell_prim_index_device(
 	}
 
 	omp_target_memcpy(new_array, shell_prim_index, mem_info.size, 0, 0,
-					  device_id, omp_get_initial_device());
+					  device_id, device_id);
 
 	ctx->ao_basis.shell_prim_index = new_array;
 
@@ -1595,8 +1588,6 @@ qmckl_exit_code qmckl_set_ao_basis_shell_factor_device(
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
 	int device_id = qmckl_get_device_id(context);
-
-	// Accepts an host array and copies it on device
 
 	int32_t mask = 1 << 8;
 
@@ -1636,7 +1627,7 @@ qmckl_exit_code qmckl_set_ao_basis_shell_factor_device(
 	}
 
 	omp_target_memcpy(new_array, shell_factor, mem_info.size, 0, 0, device_id,
-					  omp_get_initial_device());
+					  device_id);
 
 	ctx->ao_basis.shell_factor = new_array;
 
@@ -1663,8 +1654,6 @@ qmckl_set_ao_basis_exponent_device(qmckl_context_device context,
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
 	int device_id = qmckl_get_device_id(context);
-
-	// Accepts an host array and copies it on device
 
 	int32_t mask = 1 << 9;
 
@@ -1703,7 +1692,7 @@ qmckl_set_ao_basis_exponent_device(qmckl_context_device context,
 	}
 
 	omp_target_memcpy(new_array, exponent, mem_info.size, 0, 0, device_id,
-					  omp_get_initial_device());
+					  device_id);
 
 	ctx->ao_basis.exponent = new_array;
 
@@ -1730,8 +1719,6 @@ qmckl_exit_code qmckl_set_ao_basis_coefficient_device(
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
 	int device_id = qmckl_get_device_id(context);
-
-	// Accepts an host array and copies it on device
 
 	int32_t mask = 1 << 10;
 
@@ -1771,7 +1758,7 @@ qmckl_exit_code qmckl_set_ao_basis_coefficient_device(
 	}
 
 	omp_target_memcpy(new_array, coefficient, mem_info.size, 0, 0, device_id,
-					  omp_get_initial_device());
+					  device_id);
 
 	ctx->ao_basis.coefficient = new_array;
 
@@ -1838,7 +1825,7 @@ qmckl_exit_code qmckl_set_ao_basis_prim_factor_device(
 	}
 
 	omp_target_memcpy(new_array, prim_factor, mem_info.size, 0, 0, device_id,
-					  omp_get_initial_device());
+					  device_id);
 
 	ctx->ao_basis.prim_factor = new_array;
 
@@ -1867,8 +1854,6 @@ qmckl_set_ao_basis_ao_factor_device(qmckl_context_device context,
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
 	int device_id = qmckl_get_device_id(context);
-
-	// Accepts an host array and copies it on device
 
 	int32_t mask = 1 << 13;
 
@@ -1907,7 +1892,7 @@ qmckl_set_ao_basis_ao_factor_device(qmckl_context_device context,
 	}
 
 	omp_target_memcpy(new_array, ao_factor, mem_info.size, 0, 0, device_id,
-					  omp_get_initial_device());
+					  device_id);
 
 	ctx->ao_basis.ao_factor = new_array;
 
@@ -2056,7 +2041,7 @@ qmckl_exit_code qmckl_set_mo_basis_coefficient_device(
 	}
 
 	omp_target_memcpy(new_array, coefficient, mem_info.size, 0, 0, device_id,
-					  omp_get_initial_device());
+					  device_id);
 
 	ctx->mo_basis.coefficient = new_array;
 
@@ -2139,29 +2124,33 @@ qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 		mem_info.size = nucleus_num * sizeof(double);
 
-		double *nucl_charge = (double *)qmckl_malloc_host(context, mem_info);
+		double *nucl_charge_h = (double *)qmckl_malloc_host(context, mem_info);
+		double *nucl_charge_d = (double *)qmckl_malloc_device(context, mem_info);
 
-		if (nucl_charge == NULL) {
+		if (nucl_charge_h == NULL || nucl_charge_d == NULL) {
 			return qmckl_failwith(
 				(qmckl_context)context, QMCKL_ALLOCATION_FAILED,
 				"qmckl_trexio_read_nucleus_X_device", NULL);
 		}
 
-		assert(nucl_charge != NULL);
+		assert(nucl_charge_h != NULL && nucl_charge_d != NULL);
 
 		rcio =
-			trexio_read_safe_nucleus_charge_64(file, nucl_charge, nucleus_num);
+			trexio_read_safe_nucleus_charge_64(file, nucl_charge_h, nucleus_num);
 		if (rcio != TREXIO_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 								  "trexio_read_nucleus_charge",
 								  trexio_string_of_error(rcio));
 		}
 
-		rc = qmckl_set_nucleus_charge_device(context, nucl_charge,
+		qmckl_memcpy_H2D(context, nucl_charge_d, nucl_charge_h, mem_info.size);
+		rc = qmckl_set_nucleus_charge_device(context, nucl_charge_d,
 												 nucleus_num);
 
-		qmckl_free_host(context, nucl_charge);
-		nucl_charge = NULL;
+		qmckl_free_host(context, nucl_charge_h);
+		qmckl_free_device(context, nucl_charge_d);
+		nucl_charge_h = NULL;
+		nucl_charge_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;
@@ -2170,27 +2159,31 @@ qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = nucleus_num * 3 * sizeof(double);
 
-	double *nucl_coord = (double *)qmckl_malloc_host(context, mem_info);
+	double *nucl_coord_h = (double *)qmckl_malloc_host(context, mem_info);
+	double *nucl_coord_d = (double *)qmckl_malloc_device(context, mem_info);
 
-	if (nucl_coord == NULL) {
+	if (nucl_coord_h == NULL || nucl_coord_d == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
 							  "qmckl_trexio_read_nucleus_X_device", NULL);
 	}
 
-	assert(nucl_coord != NULL);
+	assert(nucl_coord_h != NULL && nucl_coord_d != NULL);
 
-	rcio = trexio_read_safe_nucleus_coord_64(file, nucl_coord, 3 * nucleus_num);
+	rcio = trexio_read_safe_nucleus_coord_64(file, nucl_coord_h, 3 * nucleus_num);
 	if (rcio != TREXIO_SUCCESS) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 							  "trexio_read_nucleus_charge",
 							  trexio_string_of_error(rcio));
 	}
 
+	qmckl_memcpy_H2D(context, nucl_coord_d, nucl_coord_h, mem_info.size);
 	rc = qmckl_set_nucleus_coord_device(
-		(qmckl_context)context, 'N', nucl_coord, 3 * nucleus_num);
+		(qmckl_context)context, 'N', nucl_coord_d, 3 * nucleus_num);
 
-	qmckl_free_host(context, nucl_coord);
-	nucl_coord = NULL;
+	qmckl_free_host(context, nucl_coord_h);
+	qmckl_free_device(context, nucl_coord_d);
+	nucl_coord_h = NULL;
+	nucl_coord_d = NULL;
 
 	if (rc != QMCKL_SUCCESS) {
 		return rc;
@@ -2282,10 +2275,13 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 
 		/* Allocate array for data */
 		mem_info.size = nucleus_num * sizeof(int64_t);
-		int64_t *nucleus_index =
+		int64_t *nucleus_index_h =
 			(int64_t *)qmckl_malloc_host(context, mem_info);
+		int64_t *nucleus_index_d =
+			(int64_t *)qmckl_malloc_device(context, mem_info);
 
-		if (nucleus_index == NULL) {
+
+		if (nucleus_index_h == NULL || nucleus_index_d == NULL) {
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED,
 								  "qmckl_trexio_read_basis_nucleus_"
@@ -2293,15 +2289,17 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 								  NULL);
 		}
 
-		assert(nucleus_index != NULL);
+		assert(nucleus_index_h != NULL && nucleus_index_d != NULL);
 
 		/* Allocate temporary array */
 		mem_info.size = shell_num * sizeof(int64_t);
 		int64_t *tmp_array = (int64_t *)qmckl_malloc_host(context, mem_info);
 
 		if (tmp_array == NULL) {
-			qmckl_free_host(context, nucleus_index);
-			nucleus_index = NULL;
+			qmckl_free_host(context, nucleus_index_h);
+			qmckl_free_device(context, nucleus_index_d);
+			nucleus_index_h = NULL;
+			nucleus_index_d = NULL;
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED,
 								  "qmckl_trexio_read_basis_nucleus_"
@@ -2317,19 +2315,24 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		if (rcio != TREXIO_SUCCESS) {
 			qmckl_free_host(context, tmp_array);
 			tmp_array = NULL;
-			qmckl_free_host(context, nucleus_index);
-			nucleus_index = NULL;
+			qmckl_free_host(context, nucleus_index_h);
+			qmckl_free_device(context, nucleus_index_d);
+			nucleus_index_h = NULL;
+			nucleus_index_d = NULL;
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 								  "trexio_read_basis_nucleus_index",
 								  trexio_string_of_error(rcio));
 		}
 
 		/* Reformat data */
+		qmckl_memcpy_H2D(context, nucleus_index_d, nucleus_index_h, mem_info.size);
 		rc = qmckl_set_ao_basis_nucleus_index_device(
-			context, nucleus_index, nucleus_num);
+			context, nucleus_index_d, nucleus_num);
 		if (rc != QMCKL_SUCCESS) {
-			qmckl_free_host(context, nucleus_index);
-			nucleus_index = NULL;
+			qmckl_free_host(context, nucleus_index_h);
+			qmckl_free_device(context, nucleus_index_d);
+			nucleus_index_h = NULL;
+			nucleus_index_d = NULL;
 			return rc;
 		}
 
@@ -2338,24 +2341,28 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			if (k < 0 || k >= nucleus_num) {
 				qmckl_free_host(context, tmp_array);
 				tmp_array = NULL;
-				qmckl_free_host(context, nucleus_index);
-				nucleus_index = NULL;
+				qmckl_free_host(context, nucleus_index_h);
+				qmckl_free_device(context, nucleus_index_d);
+				nucleus_index_h = NULL;
+				nucleus_index_d = NULL;
 				return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 									  "trexio_read_basis_nucleus_index",
 									  "Irrelevant data in TREXIO file");
 			}
-			nucleus_index[k] = i;
+			nucleus_index_h[k] = i;
 		}
 
 		qmckl_free_host(context, tmp_array);
 		tmp_array = NULL;
 
 		/* Store data */
-		rc = qmckl_set_ao_basis_nucleus_index_device(context, nucleus_index,
+		rc = qmckl_set_ao_basis_nucleus_index_device(context, nucleus_index_d,
 														 shell_num);
 
-		qmckl_free_host(context, nucleus_index);
-		nucleus_index = NULL;
+		qmckl_free_host(context, nucleus_index_h);
+		qmckl_free_device(context, nucleus_index_d);
+		nucleus_index_h = NULL;
+		nucleus_index_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;
@@ -2366,10 +2373,12 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 
 		/* Allocate array for data */
 		mem_info.size = nucleus_num * sizeof(int64_t);
-		int64_t *nucleus_shell_num =
+		int64_t *nucleus_shell_num_h =
 			(int64_t *)qmckl_malloc_host(context, mem_info);
+		int64_t *nucleus_shell_num_d =
+			(int64_t *)qmckl_malloc_device(context, mem_info);
 
-		if (nucleus_shell_num == NULL) {
+		if (nucleus_shell_num_h == NULL) {
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED,
 								  "qmckl_trexio_read_basis_nucleus_"
@@ -2377,15 +2386,16 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 								  NULL);
 		}
 
-		assert(nucleus_shell_num != NULL);
+		assert(nucleus_shell_num_h != NULL);
 
 		/* Allocate temporary array */
 		mem_info.size = shell_num * sizeof(int64_t);
 		int64_t *tmp_array = (int64_t *)qmckl_malloc_host(context, mem_info);
 
 		if (tmp_array == NULL) {
-			qmckl_free_host(context, nucleus_shell_num);
-			nucleus_shell_num = NULL;
+			qmckl_free_host(context, nucleus_shell_num_h);
+			qmckl_free_device(context, nucleus_shell_num_d);
+			nucleus_shell_num_h = NULL;
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED,
 								  "qmckl_trexio_read_basis_nucleus_"
@@ -2401,8 +2411,9 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		if (rcio != TREXIO_SUCCESS) {
 			qmckl_free_host(context, tmp_array);
 			tmp_array = NULL;
-			qmckl_free_host(context, nucleus_shell_num);
-			nucleus_shell_num = NULL;
+			qmckl_free_host(context, nucleus_shell_num_h);
+			qmckl_free_device(context, nucleus_shell_num_d);
+			nucleus_shell_num_h = NULL;
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 								  "trexio_read_basis_nucleus_shell_num",
 								  trexio_string_of_error(rcio));
@@ -2410,7 +2421,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 
 		/* Reformat data */
 		for (int i = 0; i < nucleus_num; ++i) {
-			nucleus_shell_num[i] = 0;
+			nucleus_shell_num_h[i] = 0;
 		}
 
 		for (int i = 0; i < shell_num; ++i) {
@@ -2418,24 +2429,28 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			if (k < 0 || k >= nucleus_num) {
 				qmckl_free_host(context, tmp_array);
 				tmp_array = NULL;
-				qmckl_free_host(context, nucleus_shell_num);
-				nucleus_shell_num = NULL;
+				qmckl_free_host(context, nucleus_shell_num_h);
+				qmckl_free_device(context, nucleus_shell_num_d);
+				nucleus_shell_num_h = NULL;
 				return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 									  "trexio_read_basis_nucleus_shell_num",
 									  "Irrelevant data in TREXIO file");
 			}
-			nucleus_shell_num[k] += 1;
+			nucleus_shell_num_h[k] += 1;
 		}
 
 		qmckl_free_host(context, tmp_array);
 		tmp_array = NULL;
 
 		/* Store data */
+		qmckl_memcpy_H2D(context, nucleus_shell_num_d, nucleus_shell_num_h, mem_info.size);
 		rc = qmckl_set_ao_basis_nucleus_shell_num_device(
-			context, nucleus_shell_num, shell_num);
+			context, nucleus_shell_num_d, shell_num);
 
-		qmckl_free_host(context, nucleus_shell_num);
-		nucleus_shell_num = NULL;
+		qmckl_free_host(context, nucleus_shell_num_h);
+		qmckl_free_device(context, nucleus_shell_num_d);
+		nucleus_shell_num_h = NULL;
+		nucleus_shell_num_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;
@@ -2447,10 +2462,13 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Allocate array for data */
 		mem_info.size = shell_num * sizeof(int32_t);
 
-		int32_t *shell_ang_mom =
+		int32_t *shell_ang_mom_h =
 			(int32_t *)qmckl_malloc_host(context, mem_info);
+		int32_t *shell_ang_mom_d =
+			(int32_t *)qmckl_malloc_device(context, mem_info);
 
-		if (shell_ang_mom == NULL) {
+
+		if (shell_ang_mom_h == NULL || shell_ang_mom_d == NULL) {
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED,
 								  "qmckl_trexio_read_basis_shell_"
@@ -2458,25 +2476,30 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 								  NULL);
 		}
 
-		assert(shell_ang_mom != NULL);
+		assert(shell_ang_mom_h != NULL && shell_ang_mom_d != NULL);
 
 		/* Read data */
-		rcio = trexio_read_safe_basis_shell_ang_mom_32(file, shell_ang_mom,
+		rcio = trexio_read_safe_basis_shell_ang_mom_32(file, shell_ang_mom_h,
 													   shell_num);
 		if (rcio != TREXIO_SUCCESS) {
-			qmckl_free_host(context, shell_ang_mom);
-			shell_ang_mom = NULL;
+			qmckl_free_host(context, shell_ang_mom_h);
+			qmckl_free_device(context, shell_ang_mom_d);
+			shell_ang_mom_h = NULL;
+			shell_ang_mom_d = NULL;
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 								  "trexio_read_basis_shell_ang_mom",
 								  trexio_string_of_error(rcio));
 		}
 
 		/* Store data */
-		rc = qmckl_set_ao_basis_shell_ang_mom_device(context, shell_ang_mom,
+		qmckl_memcpy_H2D(context, shell_ang_mom_d, shell_ang_mom_h, mem_info.size);
+		rc = qmckl_set_ao_basis_shell_ang_mom_device(context, shell_ang_mom_d,
 														 shell_num);
 
-		qmckl_free_host(context, shell_ang_mom);
-		shell_ang_mom = NULL;
+		qmckl_free_host(context, shell_ang_mom_h);
+		qmckl_free_device(context, shell_ang_mom_d);
+		shell_ang_mom_h = NULL;
+		shell_ang_mom_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;
@@ -2488,10 +2511,13 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Allocate array for data */
 		mem_info.size = shell_num * sizeof(int64_t);
 
-		int64_t *shell_prim_num =
+		int64_t *shell_prim_num_h =
 			(int64_t *)qmckl_malloc_host(context, mem_info);
+		int64_t *shell_prim_num_d =
+			(int64_t *)qmckl_malloc_device(context, mem_info);
 
-		if (shell_prim_num == NULL) {
+
+		if (shell_prim_num_h == NULL || shell_prim_num_d == NULL) {
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED,
 								  "qmckl_trexio_read_basis_shell_"
@@ -2499,7 +2525,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 								  NULL);
 		}
 
-		assert(shell_prim_num != NULL);
+		assert(shell_prim_num_h != NULL && shell_prim_num_d != NULL);
 
 		/* Allocate temporary array */
 		mem_info.size = prim_num * sizeof(int64_t);
@@ -2507,8 +2533,10 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		int64_t *tmp_array = (int64_t *)qmckl_malloc_host(context, mem_info);
 
 		if (tmp_array == NULL) {
-			qmckl_free_host(context, shell_prim_num);
-			shell_prim_num = NULL;
+			qmckl_free_host(context, shell_prim_num_h);
+			qmckl_free_device(context, shell_prim_num_d);
+			shell_prim_num_h = NULL;
+			shell_prim_num_d = NULL;
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED,
 								  "qmckl_trexio_read_basis_shell_"
@@ -2521,8 +2549,10 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Read data */
 		rcio = trexio_read_safe_basis_shell_index_64(file, tmp_array, prim_num);
 		if (rcio != TREXIO_SUCCESS) {
-			qmckl_free_host(context, shell_prim_num);
-			shell_prim_num = NULL;
+			qmckl_free_host(context, shell_prim_num_h);
+			qmckl_free_device(context, shell_prim_num_d);
+			shell_prim_num_h = NULL;
+			shell_prim_num_d = NULL;
 			qmckl_free_host(context, tmp_array);
 			tmp_array = NULL;
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
@@ -2532,30 +2562,34 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 
 		/* Reformat data */
 		for (int i = 0; i < shell_num; ++i) {
-			shell_prim_num[i] = 0;
+			shell_prim_num_h[i] = 0;
 		}
 
 		for (int i = 0; i < prim_num; ++i) {
 			const int k = tmp_array[i];
 			if (k < 0 || k >= shell_num) {
 				qmckl_free_host(context, tmp_array);
-				qmckl_free_host(context, shell_prim_num);
+				qmckl_free_host(context, shell_prim_num_h);
+				qmckl_free_device(context, shell_prim_num_d);
 				return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 									  "trexio_read_basis_shell_prim_num",
 									  "Irrelevant data in TREXIO file");
 			}
-			shell_prim_num[k] += 1;
+			shell_prim_num_h[k] += 1;
 		}
 
 		qmckl_free_host(context, tmp_array);
 		tmp_array = NULL;
 
 		/* Store data */
+		qmckl_memcpy_H2D(context, shell_prim_num_d, shell_prim_num_h, mem_info.size);
 		rc = qmckl_set_ao_basis_shell_prim_num_device(
-			context, shell_prim_num, shell_num);
+			context, shell_prim_num_d, shell_num);
 
-		qmckl_free_host(context, shell_prim_num);
-		shell_prim_num = NULL;
+		qmckl_free_host(context, shell_prim_num_h);
+		qmckl_free_device(context, shell_prim_num_d);
+		shell_prim_num_h = NULL;
+		shell_prim_num_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;
@@ -2567,10 +2601,13 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Allocate array for data */
 		mem_info.size = shell_num * sizeof(int64_t);
 
-		int64_t *shell_prim_index =
+		int64_t *shell_prim_index_h =
 			(int64_t *)qmckl_malloc_host(context, mem_info);
+		int64_t *shell_prim_index_d =
+			(int64_t *)qmckl_malloc_device(context, mem_info);
 
-		if (shell_prim_index == NULL) {
+
+		if (shell_prim_index_h == NULL || shell_prim_index_d == NULL) {
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED,
 								  "qmckl_trexio_read_basis_shell_"
@@ -2578,7 +2615,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 								  NULL);
 		}
 
-		assert(shell_prim_index != NULL);
+		assert(shell_prim_index_h != NULL && shell_prim_index_d != NULL);
 
 		/* Allocate temporary array */
 		mem_info.size = prim_num * sizeof(int64_t);
@@ -2598,8 +2635,10 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Read data */
 		rcio = trexio_read_safe_basis_shell_index_64(file, tmp_array, prim_num);
 		if (rcio != TREXIO_SUCCESS) {
-			qmckl_free_host(context, shell_prim_index);
-			shell_prim_index = NULL;
+			qmckl_free_host(context, shell_prim_index_h);
+			qmckl_free_device(context, shell_prim_index_d);
+			shell_prim_index_h = NULL;
+			shell_prim_index_d = NULL;
 			qmckl_free_host(context, tmp_array);
 			tmp_array = NULL;
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
@@ -2613,24 +2652,29 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			if (k < 0 || k >= shell_num) {
 				qmckl_free_host(context, tmp_array);
 				tmp_array = NULL;
-				qmckl_free_host(context, shell_prim_index);
-				shell_prim_index = NULL;
+				qmckl_free_host(context, shell_prim_index_h);
+				qmckl_free_device(context, shell_prim_index_d);
+				shell_prim_index_h = NULL;
+				shell_prim_index_d = NULL;
 				return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 									  "trexio_read_basis_shell_prim_index",
 									  "Irrelevant data in TREXIO file");
 			}
-			shell_prim_index[k] = i;
+			shell_prim_index_h[k] = i;
 		}
 
 		qmckl_free_host(context, tmp_array);
 		tmp_array = NULL;
 
 		/* Store data */
+		qmckl_memcpy_H2D(context, shell_prim_index_d, shell_prim_index_h, mem_info.size);
 		rc = qmckl_set_ao_basis_shell_prim_index_device(
-			context, shell_prim_index, shell_num);
+			context, shell_prim_index_d, shell_num);
 
-		qmckl_free_host(context, shell_prim_index);
-		shell_prim_index = NULL;
+		qmckl_free_host(context, shell_prim_index_h);
+		qmckl_free_device(context, shell_prim_index_d);
+		shell_prim_index_h = NULL;
+		shell_prim_index_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;
@@ -2642,33 +2686,39 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Allocate array for data */
 		mem_info.size = shell_num * sizeof(double);
 
-		double *shell_factor = (double *)qmckl_malloc_host(context, mem_info);
+		double *shell_factor_h = (double *)qmckl_malloc_host(context, mem_info);
+		double *shell_factor_d = (double *)qmckl_malloc_device(context, mem_info);
 
-		if (shell_factor == NULL) {
+		if (shell_factor_h == NULL || shell_factor_d == NULL) {
 			return qmckl_failwith(
 				(qmckl_context)context, QMCKL_ALLOCATION_FAILED,
 				"qmckl_trexio_read_basis_shell_factor_X_device", NULL);
 		}
 
-		assert(shell_factor != NULL);
+		assert(shell_factor_h != NULL && shell_factor_d != NULL);
 
 		/* Read data */
-		rcio = trexio_read_safe_basis_shell_factor_64(file, shell_factor,
+		rcio = trexio_read_safe_basis_shell_factor_64(file, shell_factor_h,
 													  shell_num);
 		if (rcio != TREXIO_SUCCESS) {
-			qmckl_free_host(context, shell_factor);
-			shell_factor = NULL;
+			qmckl_free_host(context, shell_factor_h);
+			qmckl_free_device(context, shell_factor_d);
+			shell_factor_h = NULL;
+			shell_factor_d = NULL;
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 								  "trexio_read_basis_shell_factor",
 								  trexio_string_of_error(rcio));
 		}
 
 		/* Store data */
-		rc = qmckl_set_ao_basis_shell_factor_device(context, shell_factor,
+		qmckl_memcpy_H2D(context, shell_factor_d, shell_factor_h, mem_info.size);
+		rc = qmckl_set_ao_basis_shell_factor_device(context, shell_factor_d,
 														shell_num);
 
-		qmckl_free_host(context, shell_factor);
-		shell_factor = NULL;
+		qmckl_free_host(context, shell_factor_h);
+		qmckl_free_device(context, shell_factor_d);
+		shell_factor_h = NULL;
+		shell_factor_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;
@@ -2680,31 +2730,37 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Allocate array for data */
 		mem_info.size = prim_num * sizeof(double);
 
-		double *exponent = (double *)qmckl_malloc_host(context, mem_info);
+		double *exponent_h = (double *)qmckl_malloc_host(context, mem_info);
+		double *exponent_d = (double *)qmckl_malloc_device(context, mem_info);
 
-		if (exponent == NULL) {
+		if (exponent_h == NULL || exponent_d == NULL) {
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED,
 								  "qmckl_trexio_read_basis_exponent_X", NULL);
 		}
 
-		assert(exponent != NULL);
+		assert(exponent_h != NULL && exponent_d != NULL);
 
 		/* Read data */
-		rcio = trexio_read_safe_basis_exponent_64(file, exponent, prim_num);
+		rcio = trexio_read_safe_basis_exponent_64(file, exponent_h, prim_num);
 		if (rcio != TREXIO_SUCCESS) {
-			qmckl_free_host(context, exponent);
-			exponent = NULL;
+			qmckl_free_host(context, exponent_h);
+			qmckl_free_device(context, exponent_d);
+			exponent_h = NULL;
+			exponent_d = NULL;
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 								  "trexio_read_basis_exponent",
 								  trexio_string_of_error(rcio));
 		}
 
 		/* Store data */
-		rc = qmckl_set_ao_basis_exponent_device(context, exponent, prim_num);
+		qmckl_memcpy_H2D(context, exponent_d, exponent_h, mem_info.size);
+		rc = qmckl_set_ao_basis_exponent_device(context, exponent_d, prim_num);
 
-		qmckl_free_host(context, exponent);
-		exponent = NULL;
+		qmckl_free_host(context, exponent_h);
+		qmckl_free_device(context, exponent_d);
+		exponent_h = NULL;
+		exponent_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;
@@ -2716,33 +2772,39 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Allocate array for data */
 		mem_info.size = prim_num * sizeof(double);
 
-		double *coefficient = (double *)qmckl_malloc_host(context, mem_info);
+		double *coefficient_h = (double *)qmckl_malloc_host(context, mem_info);
+		double *coefficient_d = (double *)qmckl_malloc_device(context, mem_info);
 
-		if (coefficient == NULL) {
+		if (coefficient_h == NULL || coefficient_d == NULL) {
 			return qmckl_failwith(
 				(qmckl_context)context, QMCKL_ALLOCATION_FAILED,
 				"qmckl_trexio_read_basis_coefficient_X_device", NULL);
 		}
 
-		assert(coefficient != NULL);
+		assert(coefficient_h != NULL && coefficient_d != NULL);
 
 		/* Read data */
 		rcio =
-			trexio_read_safe_basis_coefficient_64(file, coefficient, prim_num);
+			trexio_read_safe_basis_coefficient_64(file, coefficient_h, prim_num);
 		if (rcio != TREXIO_SUCCESS) {
-			qmckl_free_host(context, coefficient);
-			coefficient = NULL;
+			qmckl_free_host(context, coefficient_h);
+			qmckl_free_device(context, coefficient_d);
+			coefficient_h = NULL;
+			coefficient_d = NULL;
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 								  "trexio_read_basis_coefficient",
 								  trexio_string_of_error(rcio));
 		}
 
 		/* Store data */
-		rc = qmckl_set_ao_basis_coefficient_device(context, coefficient,
+		qmckl_memcpy_H2D(context, coefficient_d, coefficient_h, mem_info.size);
+		rc = qmckl_set_ao_basis_coefficient_device(context, coefficient_d,
 													   prim_num);
 
-		qmckl_free_host(context, coefficient);
-		coefficient = NULL;
+		qmckl_free_host(context, coefficient_h);
+		qmckl_free_device(context, coefficient_d);
+		coefficient_h = NULL;
+		coefficient_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;
@@ -2754,33 +2816,39 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Allocate array for data */
 		mem_info.size = prim_num * sizeof(double);
 
-		double *prim_factor = (double *)qmckl_malloc_host(context, mem_info);
+		double *prim_factor_h = (double *)qmckl_malloc_host(context, mem_info);
+		double *prim_factor_d = (double *)qmckl_malloc_device(context, mem_info);
 
-		if (prim_factor == NULL) {
+		if (prim_factor_h == NULL || prim_factor_d == NULL) {
 			return qmckl_failwith(
 				(qmckl_context)context, QMCKL_ALLOCATION_FAILED,
 				"qmckl_trexio_read_basis_prim_factor_X_device", NULL);
 		}
 
-		assert(prim_factor != NULL);
+		assert(prim_factor_h != NULL && prim_factor_d != NULL);
 
 		/* Read data */
 		rcio =
-			trexio_read_safe_basis_prim_factor_64(file, prim_factor, prim_num);
+			trexio_read_safe_basis_prim_factor_64(file, prim_factor_h, prim_num);
 		if (rcio != TREXIO_SUCCESS) {
-			qmckl_free_host(context, prim_factor);
-			prim_factor = NULL;
+			qmckl_free_host(context, prim_factor_h);
+			qmckl_free_device(context, prim_factor_d);
+			prim_factor_h = NULL;
+			prim_factor_d = NULL;
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 								  "trexio_read_basis_prim_factor",
 								  trexio_string_of_error(rcio));
 		}
 
 		/* Read data */
-		rc = qmckl_set_ao_basis_prim_factor_device(context, prim_factor,
+		qmckl_memcpy_H2D(context, prim_factor_d, prim_factor_h, mem_info.size);
+		rc = qmckl_set_ao_basis_prim_factor_device(context, prim_factor_d,
 													   prim_num);
 
-		qmckl_free_host((qmckl_context)context, prim_factor);
-		prim_factor = NULL;
+		qmckl_free_host(context, prim_factor_h);
+		qmckl_free_device(context, prim_factor_d);
+		prim_factor_h = NULL;
+		prim_factor_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;
@@ -2792,34 +2860,42 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Allocate array for data */
 		mem_info.size = ao_num * sizeof(double);
 
-		double *ao_normalization =
+		double *ao_normalization_h =
 			(double *)qmckl_malloc_host(context, mem_info);
+		double *ao_normalization_d =
+			(double *)qmckl_malloc_device(context, mem_info);
 
-		if (ao_normalization == NULL) {
+
+		if (ao_normalization_h == NULL || ao_normalization_d == NULL) {
 			return qmckl_failwith(
 				(qmckl_context)context, QMCKL_ALLOCATION_FAILED,
 				"qmckl_trexio_read_ao_normalization_X_device", NULL);
 		}
 
-		assert(ao_normalization != NULL);
+		assert(ao_normalization_h != NULL && ao_normalization_d != NULL);
 
 		/* Read data */
-		rcio = trexio_read_safe_ao_normalization_64(file, ao_normalization,
+		rcio = trexio_read_safe_ao_normalization_64(file, ao_normalization_h,
 													ao_num);
 		if (rcio != TREXIO_SUCCESS) {
-			qmckl_free_host(context, ao_normalization);
-			ao_normalization = NULL;
+			qmckl_free_host(context, ao_normalization_h);
+			qmckl_free_device(context, ao_normalization_d);
+			ao_normalization_h = NULL;
+			ao_normalization_d = NULL;
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 								  "trexio_read_ao_normalization",
 								  trexio_string_of_error(rcio));
 		}
 
 		/* Store data */
-		rc = qmckl_set_ao_basis_ao_factor_device(context, ao_normalization,
+		qmckl_memcpy_H2D(context, ao_normalization_d, ao_normalization_h, mem_info.size);
+		rc = qmckl_set_ao_basis_ao_factor_device(context, ao_normalization_d,
 													 ao_num);
 
-		qmckl_free_host(context, ao_normalization);
-		ao_normalization = NULL;
+		qmckl_free_host(context, ao_normalization_h);
+		qmckl_free_device(context, ao_normalization_d);
+		ao_normalization_h = NULL;
+		ao_normalization_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;
@@ -2860,27 +2936,31 @@ qmckl_exit_code qmckl_trexio_read_mo_X_device(qmckl_context_device context,
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 		mem_info.size = ao_num * mo_num * sizeof(double);
 
-		double *mo_coef = (double *)qmckl_malloc_host(context, mem_info);
+		double *mo_coef_h = (double *)qmckl_malloc_host(context, mem_info);
+		double *mo_coef_d = (double *)qmckl_malloc_device(context, mem_info);
 
-		if (mo_coef == NULL) {
+		if (mo_coef_h == NULL || mo_coef_d == NULL) {
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED,
 								  "qmckl_trexio_read_mo_X_device", NULL);
 		}
 
-		assert(mo_coef != NULL);
+		assert(mo_coef_h != NULL && mo_coef_d != NULL);
 
-		rcio = trexio_read_mo_coefficient_64(file, mo_coef);
+		rcio = trexio_read_mo_coefficient_64(file, mo_coef_h);
 		if (rcio != TREXIO_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 								  "trexio_read_mo_coefficient",
 								  trexio_string_of_error(rcio));
 		}
 
-		rc = qmckl_set_mo_basis_coefficient_device(context, mo_coef);
+		qmckl_memcpy_H2D(context, mo_coef_d, mo_coef_h, mem_info.size);
+		rc = qmckl_set_mo_basis_coefficient_device(context, mo_coef_d);
 
-		qmckl_free_host(context, mo_coef);
-		mo_coef = NULL;
+		qmckl_free_host(context, mo_coef_h);
+		qmckl_free_device(context, mo_coef_d);
+		mo_coef_h = NULL;
+		mo_coef_d = NULL;
 
 		if (rc != QMCKL_SUCCESS)
 			return rc;

--- a/src/qmckl_trexio_omp_device.c
+++ b/src/qmckl_trexio_omp_device.c
@@ -10,11 +10,10 @@
 // ELECTRON/POINT GETTERS/SETTERS
 //**********
 
-
 qmckl_exit_code qmckl_set_point_device(qmckl_context_device context,
-										   const char transp, const int64_t num,
-										   const double *coord,
-										   const int64_t size_max) {
+									   const char transp, const int64_t num,
+									   const double *coord,
+									   const int64_t size_max) {
 
 	const size_t device_id = qmckl_get_device_id(context);
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
@@ -49,8 +48,7 @@ qmckl_exit_code qmckl_set_point_device(qmckl_context_device context,
 			assert(rc == QMCKL_SUCCESS);
 		}
 
-		ctx->point.coord =
-			qmckl_matrix_alloc_device(context, num, 3);
+		ctx->point.coord = qmckl_matrix_alloc_device(context, num, 3);
 		if (ctx->point.coord.data == NULL) {
 			return qmckl_failwith((qmckl_context)context,
 								  QMCKL_ALLOCATION_FAILED, "qmckl_set_point",
@@ -88,10 +86,10 @@ qmckl_exit_code qmckl_set_point_device(qmckl_context_device context,
 }
 
 qmckl_exit_code qmckl_set_electron_coord_device(qmckl_context context,
-													const char transp,
-													const int64_t walk_num,
-													const double *coord,
-													const int64_t size_max) {
+												const char transp,
+												const int64_t walk_num,
+												const double *coord,
+												const int64_t size_max) {
 
 	const size_t device_id = qmckl_get_device_id(context);
 	int32_t mask = 0; // coord can be changed
@@ -143,7 +141,7 @@ qmckl_exit_code qmckl_set_electron_coord_device(qmckl_context context,
 
 	qmckl_exit_code rc;
 	rc = qmckl_set_point_device(context, transp, walk_num * elec_num, coord,
-									size_max);
+								size_max);
 	if (rc != QMCKL_SUCCESS)
 		return rc;
 
@@ -158,11 +156,9 @@ qmckl_exit_code qmckl_set_electron_coord_device(qmckl_context context,
 // NUCLEUS GETTERS/SETTERS
 //**********
 
-
-qmckl_exit_code
-qmckl_set_nucleus_charge_device(qmckl_context_device context,
-									const double *charge,
-									const int64_t size_max) {
+qmckl_exit_code qmckl_set_nucleus_charge_device(qmckl_context_device context,
+												const double *charge,
+												const int64_t size_max) {
 
 	int32_t mask = 1 << 1;
 
@@ -192,10 +188,9 @@ qmckl_set_nucleus_charge_device(qmckl_context_device context,
 							  "Array too small");
 	}
 
-	ctx->nucleus.charge =
-		qmckl_vector_alloc_device(context, num);
+	ctx->nucleus.charge = qmckl_vector_alloc_device(context, num);
 	rc = qmckl_vector_of_double_device(context, charge, num,
-										   &(ctx->nucleus.charge));
+									   &(ctx->nucleus.charge));
 
 	if (rc != QMCKL_SUCCESS) {
 		return qmckl_failwith(context, QMCKL_FAILURE,
@@ -210,9 +205,9 @@ qmckl_set_nucleus_charge_device(qmckl_context_device context,
 }
 
 qmckl_exit_code qmckl_set_nucleus_coord_device(qmckl_context_device context,
-												   const char transp,
-												   const double *coord,
-												   const int64_t size_max) {
+											   const char transp,
+											   const double *coord,
+											   const int64_t size_max) {
 	int32_t mask = 1 << 2;
 
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
@@ -231,8 +226,7 @@ qmckl_exit_code qmckl_set_nucleus_coord_device(qmckl_context_device context,
 			return rc;
 	}
 
-	ctx->nucleus.coord =
-		qmckl_matrix_alloc_device(context, nucl_num, 3);
+	ctx->nucleus.coord = qmckl_matrix_alloc_device(context, nucl_num, 3);
 
 #pragma use_device_ptr(ctx->nucleus.coord.data)
 	{
@@ -252,14 +246,13 @@ qmckl_exit_code qmckl_set_nucleus_coord_device(qmckl_context_device context,
 	if (transp == 'N') {
 		qmckl_matrix At;
 		At = qmckl_matrix_alloc_device(context, 3, nucl_num);
-		rc = qmckl_matrix_of_double_device(context, coord, 3 * nucl_num,
-											   &At);
+		rc = qmckl_matrix_of_double_device(context, coord, 3 * nucl_num, &At);
 		if (rc != QMCKL_SUCCESS)
 			return rc;
 		rc = qmckl_transpose_device(context, At, ctx->nucleus.coord);
 	} else {
-		rc = qmckl_matrix_of_double_device(
-			context, coord, nucl_num * 3, &(ctx->nucleus.coord));
+		rc = qmckl_matrix_of_double_device(context, coord, nucl_num * 3,
+										   &(ctx->nucleus.coord));
 	}
 	if (rc != QMCKL_SUCCESS)
 		return rc;
@@ -1085,7 +1078,7 @@ qmckl_exit_code qmckl_finalize_ao_basis_device(qmckl_context_device context) {
 }
 
 qmckl_exit_code qmckl_set_ao_basis_type_device(qmckl_context_device context,
-												   const char basis_type) {
+											   const char basis_type) {
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
 							  "qmckl_set_ao_basis_type_device", NULL);
@@ -1105,8 +1098,7 @@ qmckl_exit_code qmckl_set_ao_basis_type_device(qmckl_context_device context,
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1114,8 +1106,9 @@ qmckl_exit_code qmckl_set_ao_basis_type_device(qmckl_context_device context,
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code qmckl_set_ao_basis_shell_num_device(
-	qmckl_context_device context, const int64_t shell_num) {
+qmckl_exit_code
+qmckl_set_ao_basis_shell_num_device(qmckl_context_device context,
+									const int64_t shell_num) {
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
 							  "qmckl_set_ao_basis_shell_num_device", NULL);
@@ -1143,8 +1136,7 @@ qmckl_exit_code qmckl_set_ao_basis_shell_num_device(
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1152,9 +1144,8 @@ qmckl_exit_code qmckl_set_ao_basis_shell_num_device(
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code
-qmckl_set_ao_basis_prim_num_device(qmckl_context_device context,
-									   const int64_t prim_num) {
+qmckl_exit_code qmckl_set_ao_basis_prim_num_device(qmckl_context_device context,
+												   const int64_t prim_num) {
 
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
@@ -1189,8 +1180,7 @@ qmckl_set_ao_basis_prim_num_device(qmckl_context_device context,
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1198,9 +1188,8 @@ qmckl_set_ao_basis_prim_num_device(qmckl_context_device context,
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code
-qmckl_set_ao_basis_ao_num_device(qmckl_context_device context,
-									 const int64_t ao_num) {
+qmckl_exit_code qmckl_set_ao_basis_ao_num_device(qmckl_context_device context,
+												 const int64_t ao_num) {
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
 							  "qmckl_set_ao_basis_ao_num_device", NULL);
@@ -1233,8 +1222,7 @@ qmckl_set_ao_basis_ao_num_device(qmckl_context_device context,
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1242,13 +1230,13 @@ qmckl_set_ao_basis_ao_num_device(qmckl_context_device context,
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code qmckl_set_ao_basis_nucleus_index_device(
-	qmckl_context_device context, const int64_t *nucleus_index,
-	const int64_t size_max) {
+qmckl_exit_code
+qmckl_set_ao_basis_nucleus_index_device(qmckl_context_device context,
+										const int64_t *nucleus_index,
+										const int64_t size_max) {
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
-							  "qmckl_set_ao_basis_nucleus_index_device",
-							  NULL);
+							  "qmckl_set_ao_basis_nucleus_index_device", NULL);
 	}
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
@@ -1271,8 +1259,8 @@ qmckl_exit_code qmckl_set_ao_basis_nucleus_index_device(
 	}
 
 	if (ctx->ao_basis.nucleus_index != NULL) {
-		qmckl_exit_code rc = qmckl_free_device(
-			context, ctx->ao_basis.nucleus_index);
+		qmckl_exit_code rc =
+			qmckl_free_device(context, ctx->ao_basis.nucleus_index);
 		if (rc != QMCKL_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, rc,
 								  "qmckl_set_ao_basis_nucleus_index_device",
@@ -1282,13 +1270,11 @@ qmckl_exit_code qmckl_set_ao_basis_nucleus_index_device(
 
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = nucl_num * sizeof(int64_t);
-	int64_t *new_array =
-		(int64_t *)qmckl_malloc_device(context, mem_info);
+	int64_t *new_array = (int64_t *)qmckl_malloc_device(context, mem_info);
 
 	if (new_array == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
-							  "qmckl_set_ao_basis_nucleus_index_device",
-							  NULL);
+							  "qmckl_set_ao_basis_nucleus_index_device", NULL);
 	}
 
 	omp_target_memcpy(new_array, nucleus_index, mem_info.size, 0, 0, device_id,
@@ -1299,8 +1285,7 @@ qmckl_exit_code qmckl_set_ao_basis_nucleus_index_device(
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1308,9 +1293,10 @@ qmckl_exit_code qmckl_set_ao_basis_nucleus_index_device(
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code qmckl_set_ao_basis_nucleus_shell_num_device(
-	qmckl_context_device context, const int64_t *nucleus_shell_num,
-	const int64_t size_max) {
+qmckl_exit_code
+qmckl_set_ao_basis_nucleus_shell_num_device(qmckl_context_device context,
+											const int64_t *nucleus_shell_num,
+											const int64_t size_max) {
 
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
@@ -1338,19 +1324,18 @@ qmckl_exit_code qmckl_set_ao_basis_nucleus_shell_num_device(
 	}
 
 	if (ctx->ao_basis.nucleus_shell_num != NULL) {
-		qmckl_exit_code rc = qmckl_free_device(
-			context, ctx->ao_basis.nucleus_shell_num);
+		qmckl_exit_code rc =
+			qmckl_free_device(context, ctx->ao_basis.nucleus_shell_num);
 		if (rc != QMCKL_SUCCESS) {
-			return qmckl_failwith(
-				context, rc, "qmckl_set_ao_basis_nucleus_shell_num_device",
-				NULL);
+			return qmckl_failwith(context, rc,
+								  "qmckl_set_ao_basis_nucleus_shell_num_device",
+								  NULL);
 		}
 	}
 
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = nucl_num * sizeof(int64_t);
-	int64_t *new_array =
-		(int64_t *)qmckl_malloc_device(context, mem_info);
+	int64_t *new_array = (int64_t *)qmckl_malloc_device(context, mem_info);
 
 	if (new_array == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
@@ -1366,8 +1351,7 @@ qmckl_exit_code qmckl_set_ao_basis_nucleus_shell_num_device(
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1375,14 +1359,14 @@ qmckl_exit_code qmckl_set_ao_basis_nucleus_shell_num_device(
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code qmckl_set_ao_basis_shell_ang_mom_device(
-	qmckl_context_device context, const int32_t *shell_ang_mom,
-	const int64_t size_max) {
+qmckl_exit_code
+qmckl_set_ao_basis_shell_ang_mom_device(qmckl_context_device context,
+										const int32_t *shell_ang_mom,
+										const int64_t size_max) {
 
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
-							  "qmckl_set_ao_basis_shell_ang_mom_device",
-							  NULL);
+							  "qmckl_set_ao_basis_shell_ang_mom_device", NULL);
 	}
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
@@ -1405,8 +1389,8 @@ qmckl_exit_code qmckl_set_ao_basis_shell_ang_mom_device(
 	}
 
 	if (ctx->ao_basis.shell_ang_mom != NULL) {
-		qmckl_exit_code rc = qmckl_free_device(
-			context, ctx->ao_basis.shell_ang_mom);
+		qmckl_exit_code rc =
+			qmckl_free_device(context, ctx->ao_basis.shell_ang_mom);
 		if (rc != QMCKL_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, rc,
 								  "qmckl_set_ao_basis_shell_ang_mom_device",
@@ -1416,13 +1400,11 @@ qmckl_exit_code qmckl_set_ao_basis_shell_ang_mom_device(
 
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = shell_num * sizeof(int32_t);
-	int32_t *new_array =
-		(int32_t *)qmckl_malloc_device(context, mem_info);
+	int32_t *new_array = (int32_t *)qmckl_malloc_device(context, mem_info);
 
 	if (new_array == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
-							  "qmckl_set_ao_basis_shell_ang_mom_device",
-							  NULL);
+							  "qmckl_set_ao_basis_shell_ang_mom_device", NULL);
 	}
 
 	omp_target_memcpy(new_array, shell_ang_mom, mem_info.size, 0, 0, device_id,
@@ -1433,8 +1415,7 @@ qmckl_exit_code qmckl_set_ao_basis_shell_ang_mom_device(
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1442,9 +1423,10 @@ qmckl_exit_code qmckl_set_ao_basis_shell_ang_mom_device(
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code qmckl_set_ao_basis_shell_prim_num_device(
-	qmckl_context_device context, const int64_t *shell_prim_num,
-	const int64_t size_max) {
+qmckl_exit_code
+qmckl_set_ao_basis_shell_prim_num_device(qmckl_context_device context,
+										 const int64_t *shell_prim_num,
+										 const int64_t size_max) {
 
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith(
@@ -1472,24 +1454,22 @@ qmckl_exit_code qmckl_set_ao_basis_shell_prim_num_device(
 	}
 
 	if (ctx->ao_basis.shell_prim_num != NULL) {
-		qmckl_exit_code rc = qmckl_free_device(
-			context, ctx->ao_basis.shell_prim_num);
+		qmckl_exit_code rc =
+			qmckl_free_device(context, ctx->ao_basis.shell_prim_num);
 		if (rc != QMCKL_SUCCESS) {
-			return qmckl_failwith(
-				(qmckl_context)context, rc,
-				"qmckl_set_ao_basis_shell_prim_num_device", NULL);
+			return qmckl_failwith((qmckl_context)context, rc,
+								  "qmckl_set_ao_basis_shell_prim_num_device",
+								  NULL);
 		}
 	}
 
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = shell_num * sizeof(int64_t);
-	int64_t *new_array =
-		(int64_t *)qmckl_malloc_device(context, mem_info);
+	int64_t *new_array = (int64_t *)qmckl_malloc_device(context, mem_info);
 
 	if (new_array == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
-							  "qmckl_set_ao_basis_shell_prim_num_device",
-							  NULL);
+							  "qmckl_set_ao_basis_shell_prim_num_device", NULL);
 	}
 
 	omp_target_memcpy(new_array, shell_prim_num, mem_info.size, 0, 0, device_id,
@@ -1500,8 +1480,7 @@ qmckl_exit_code qmckl_set_ao_basis_shell_prim_num_device(
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1509,9 +1488,10 @@ qmckl_exit_code qmckl_set_ao_basis_shell_prim_num_device(
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code qmckl_set_ao_basis_shell_prim_index_device(
-	qmckl_context_device context, const int64_t *shell_prim_index,
-	const int64_t size_max) {
+qmckl_exit_code
+qmckl_set_ao_basis_shell_prim_index_device(qmckl_context_device context,
+										   const int64_t *shell_prim_index,
+										   const int64_t size_max) {
 
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
@@ -1539,19 +1519,18 @@ qmckl_exit_code qmckl_set_ao_basis_shell_prim_index_device(
 	}
 
 	if (ctx->ao_basis.shell_prim_index != NULL) {
-		qmckl_exit_code rc = qmckl_free_device(
-			context, ctx->ao_basis.shell_prim_index);
+		qmckl_exit_code rc =
+			qmckl_free_device(context, ctx->ao_basis.shell_prim_index);
 		if (rc != QMCKL_SUCCESS) {
-			return qmckl_failwith(
-				(qmckl_context)context, rc,
-				"qmckl_set_ao_basis_shell_prim_index_device", NULL);
+			return qmckl_failwith((qmckl_context)context, rc,
+								  "qmckl_set_ao_basis_shell_prim_index_device",
+								  NULL);
 		}
 	}
 
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = shell_num * sizeof(int64_t);
-	int64_t *new_array =
-		(int64_t *)qmckl_malloc_device(context, mem_info);
+	int64_t *new_array = (int64_t *)qmckl_malloc_device(context, mem_info);
 
 	if (new_array == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
@@ -1567,8 +1546,7 @@ qmckl_exit_code qmckl_set_ao_basis_shell_prim_index_device(
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1576,14 +1554,14 @@ qmckl_exit_code qmckl_set_ao_basis_shell_prim_index_device(
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code qmckl_set_ao_basis_shell_factor_device(
-	qmckl_context_device context, const double *shell_factor,
-	const int64_t size_max) {
+qmckl_exit_code
+qmckl_set_ao_basis_shell_factor_device(qmckl_context_device context,
+									   const double *shell_factor,
+									   const int64_t size_max) {
 
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
-							  "qmckl_set_ao_basis_shell_factor_device",
-							  NULL);
+							  "qmckl_set_ao_basis_shell_factor_device", NULL);
 	}
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
@@ -1606,8 +1584,8 @@ qmckl_exit_code qmckl_set_ao_basis_shell_factor_device(
 	}
 
 	if (ctx->ao_basis.shell_factor != NULL) {
-		qmckl_exit_code rc = qmckl_free_device(
-			context, ctx->ao_basis.shell_factor);
+		qmckl_exit_code rc =
+			qmckl_free_device(context, ctx->ao_basis.shell_factor);
 		if (rc != QMCKL_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, rc,
 								  "qmckl_set_ao_basis_shell_factor_device",
@@ -1617,13 +1595,11 @@ qmckl_exit_code qmckl_set_ao_basis_shell_factor_device(
 
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = shell_num * sizeof(double);
-	double *new_array =
-		(double *)qmckl_malloc_device(context, mem_info);
+	double *new_array = (double *)qmckl_malloc_device(context, mem_info);
 
 	if (new_array == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
-							  "qmckl_set_ao_basis_shell_factor_device",
-							  NULL);
+							  "qmckl_set_ao_basis_shell_factor_device", NULL);
 	}
 
 	omp_target_memcpy(new_array, shell_factor, mem_info.size, 0, 0, device_id,
@@ -1634,8 +1610,7 @@ qmckl_exit_code qmckl_set_ao_basis_shell_factor_device(
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1643,10 +1618,9 @@ qmckl_exit_code qmckl_set_ao_basis_shell_factor_device(
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code
-qmckl_set_ao_basis_exponent_device(qmckl_context_device context,
-									   const double *exponent,
-									   const int64_t size_max) {
+qmckl_exit_code qmckl_set_ao_basis_exponent_device(qmckl_context_device context,
+												   const double *exponent,
+												   const int64_t size_max) {
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
 							  "qmckl_set_ao_basis_exponent_device", NULL);
@@ -1672,19 +1646,16 @@ qmckl_set_ao_basis_exponent_device(qmckl_context_device context,
 	}
 
 	if (ctx->ao_basis.exponent != NULL) {
-		qmckl_exit_code rc =
-			qmckl_free_device(context, ctx->ao_basis.exponent);
+		qmckl_exit_code rc = qmckl_free_device(context, ctx->ao_basis.exponent);
 		if (rc != QMCKL_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, rc,
-								  "qmckl_set_ao_basis_exponent_device",
-								  NULL);
+								  "qmckl_set_ao_basis_exponent_device", NULL);
 		}
 	}
 
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = prim_num * sizeof(double);
-	double *new_array =
-		(double *)qmckl_malloc_device(context, mem_info);
+	double *new_array = (double *)qmckl_malloc_device(context, mem_info);
 
 	if (new_array == NULL) {
 		return qmckl_failwith(context, QMCKL_ALLOCATION_FAILED,
@@ -1699,8 +1670,7 @@ qmckl_set_ao_basis_exponent_device(qmckl_context_device context,
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1708,13 +1678,13 @@ qmckl_set_ao_basis_exponent_device(qmckl_context_device context,
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code qmckl_set_ao_basis_coefficient_device(
-	qmckl_context_device context, const double *coefficient,
-	const int64_t size_max) {
+qmckl_exit_code
+qmckl_set_ao_basis_coefficient_device(qmckl_context_device context,
+									  const double *coefficient,
+									  const int64_t size_max) {
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
-							  "qmckl_set_ao_basis_coefficient_device",
-							  NULL);
+							  "qmckl_set_ao_basis_coefficient_device", NULL);
 	}
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
@@ -1737,8 +1707,8 @@ qmckl_exit_code qmckl_set_ao_basis_coefficient_device(
 	}
 
 	if (ctx->ao_basis.coefficient != NULL) {
-		qmckl_exit_code rc = qmckl_free_device(
-			context, ctx->ao_basis.coefficient);
+		qmckl_exit_code rc =
+			qmckl_free_device(context, ctx->ao_basis.coefficient);
 		if (rc != QMCKL_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, rc,
 								  "qmckl_set_ao_basis_coefficient_device",
@@ -1748,13 +1718,11 @@ qmckl_exit_code qmckl_set_ao_basis_coefficient_device(
 
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = prim_num * sizeof(double);
-	double *new_array =
-		(double *)qmckl_malloc_device(context, mem_info);
+	double *new_array = (double *)qmckl_malloc_device(context, mem_info);
 
 	if (new_array == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
-							  "qmckl_set_ao_basis_coefficient_device",
-							  NULL);
+							  "qmckl_set_ao_basis_coefficient_device", NULL);
 	}
 
 	omp_target_memcpy(new_array, coefficient, mem_info.size, 0, 0, device_id,
@@ -1765,8 +1733,7 @@ qmckl_exit_code qmckl_set_ao_basis_coefficient_device(
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1774,12 +1741,12 @@ qmckl_exit_code qmckl_set_ao_basis_coefficient_device(
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code qmckl_set_ao_basis_prim_factor_device(
-	qmckl_context context, const double *prim_factor, const int64_t size_max) {
+qmckl_exit_code qmckl_set_ao_basis_prim_factor_device(qmckl_context context,
+													  const double *prim_factor,
+													  const int64_t size_max) {
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
-							  "qmckl_set_ao_basis_prim_factor_device",
-							  NULL);
+							  "qmckl_set_ao_basis_prim_factor_device", NULL);
 	}
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
@@ -1804,8 +1771,8 @@ qmckl_exit_code qmckl_set_ao_basis_prim_factor_device(
 	}
 
 	if (ctx->ao_basis.prim_factor != NULL) {
-		qmckl_exit_code rc = qmckl_free_device(
-			context, ctx->ao_basis.prim_factor);
+		qmckl_exit_code rc =
+			qmckl_free_device(context, ctx->ao_basis.prim_factor);
 		if (rc != QMCKL_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, rc,
 								  "qmckl_set_ao_basis_prim_factor_device",
@@ -1815,13 +1782,11 @@ qmckl_exit_code qmckl_set_ao_basis_prim_factor_device(
 
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = prim_num * sizeof(double);
-	double *new_array =
-		(double *)qmckl_malloc_device(context, mem_info);
+	double *new_array = (double *)qmckl_malloc_device(context, mem_info);
 
 	if (new_array == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
-							  "qmckl_set_ao_basis_prim_factor_device",
-							  NULL);
+							  "qmckl_set_ao_basis_prim_factor_device", NULL);
 	}
 
 	omp_target_memcpy(new_array, prim_factor, mem_info.size, 0, 0, device_id,
@@ -1832,8 +1797,7 @@ qmckl_exit_code qmckl_set_ao_basis_prim_factor_device(
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1843,13 +1807,12 @@ qmckl_exit_code qmckl_set_ao_basis_prim_factor_device(
 
 qmckl_exit_code
 qmckl_set_ao_basis_ao_factor_device(qmckl_context_device context,
-										const double *ao_factor,
-										const int64_t size_max) {
+									const double *ao_factor,
+									const int64_t size_max) {
 
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_INVALID_CONTEXT,
-							  "qmckl_set_ao_basis_prim_factor_device",
-							  NULL);
+							  "qmckl_set_ao_basis_prim_factor_device", NULL);
 	}
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
@@ -1876,15 +1839,13 @@ qmckl_set_ao_basis_ao_factor_device(qmckl_context_device context,
 			qmckl_free_device(context, ctx->ao_basis.ao_factor);
 		if (rc != QMCKL_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, rc,
-								  "qmckl_set_ao_basis_ao_factor_device",
-								  NULL);
+								  "qmckl_set_ao_basis_ao_factor_device", NULL);
 		}
 	}
 
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size = ao_num * sizeof(double);
-	double *new_array =
-		(double *)qmckl_malloc_device(context, mem_info);
+	double *new_array = (double *)qmckl_malloc_device(context, mem_info);
 
 	if (new_array == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
@@ -1899,8 +1860,7 @@ qmckl_set_ao_basis_ao_factor_device(qmckl_context_device context,
 	ctx->ao_basis.uninitialized &= ~mask;
 	ctx->ao_basis.provided = (ctx->ao_basis.uninitialized == 0);
 	if (ctx->ao_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_ao_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_ao_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -1925,8 +1885,7 @@ qmckl_exit_code qmckl_finalize_mo_basis_device(qmckl_context_device context) {
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size =
 		ctx->ao_basis.ao_num * ctx->mo_basis.mo_num * sizeof(double);
-	double *new_array =
-		(double *)qmckl_malloc_device(context, mem_info);
+	double *new_array = (double *)qmckl_malloc_device(context, mem_info);
 	if (new_array == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
 							  "qmckl_finalize_mo_basis_device", NULL);
@@ -1935,8 +1894,8 @@ qmckl_exit_code qmckl_finalize_mo_basis_device(qmckl_context_device context) {
 	assert(ctx->mo_basis.coefficient != NULL);
 
 	if (ctx->mo_basis.coefficient_t != NULL) {
-		qmckl_exit_code rc = qmckl_free_device(
-			context, ctx->mo_basis.coefficient_t);
+		qmckl_exit_code rc =
+			qmckl_free_device(context, ctx->mo_basis.coefficient_t);
 		if (rc != QMCKL_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, rc,
 								  "qmckl_finalize_mo_basis_device", NULL);
@@ -1963,9 +1922,8 @@ qmckl_exit_code qmckl_finalize_mo_basis_device(qmckl_context_device context) {
 	return rc;
 }
 
-qmckl_exit_code
-qmckl_set_mo_basis_mo_num_device(qmckl_context_device context,
-									 const int64_t mo_num) {
+qmckl_exit_code qmckl_set_mo_basis_mo_num_device(qmckl_context_device context,
+												 const int64_t mo_num) {
 
 	int32_t mask = 1;
 
@@ -1991,8 +1949,7 @@ qmckl_set_mo_basis_mo_num_device(qmckl_context_device context,
 	ctx->mo_basis.uninitialized &= ~mask;
 	ctx->mo_basis.provided = (ctx->mo_basis.uninitialized == 0);
 	if (ctx->mo_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_mo_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_mo_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -2000,8 +1957,9 @@ qmckl_set_mo_basis_mo_num_device(qmckl_context_device context,
 	return QMCKL_SUCCESS;
 }
 
-qmckl_exit_code qmckl_set_mo_basis_coefficient_device(
-	qmckl_context context, const double *coefficient) {
+qmckl_exit_code
+qmckl_set_mo_basis_coefficient_device(qmckl_context context,
+									  const double *coefficient) {
 
 	int32_t mask = 1 << 1;
 
@@ -2015,13 +1973,12 @@ qmckl_exit_code qmckl_set_mo_basis_coefficient_device(
 
 	if (mask != 0 && !(ctx->mo_basis.uninitialized & mask)) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALREADY_SET,
-							  "qmckl_set_mo_basis_coefficient_device",
-							  NULL);
+							  "qmckl_set_mo_basis_coefficient_device", NULL);
 	}
 
 	if (ctx->mo_basis.coefficient != NULL) {
-		qmckl_exit_code rc = qmckl_free_device(
-			context, ctx->mo_basis.coefficient);
+		qmckl_exit_code rc =
+			qmckl_free_device(context, ctx->mo_basis.coefficient);
 		if (rc != QMCKL_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, rc,
 								  "qmckl_set_mo_basis_coefficient_device",
@@ -2032,12 +1989,10 @@ qmckl_exit_code qmckl_set_mo_basis_coefficient_device(
 	qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 	mem_info.size =
 		ctx->ao_basis.ao_num * ctx->mo_basis.mo_num * sizeof(double);
-	double *new_array =
-		(double *)qmckl_malloc_device(context, mem_info);
+	double *new_array = (double *)qmckl_malloc_device(context, mem_info);
 	if (new_array == NULL) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_ALLOCATION_FAILED,
-							  "qmckl_set_mo_basis_coefficient_device",
-							  NULL);
+							  "qmckl_set_mo_basis_coefficient_device", NULL);
 	}
 
 	omp_target_memcpy(new_array, coefficient, mem_info.size, 0, 0, device_id,
@@ -2048,8 +2003,7 @@ qmckl_exit_code qmckl_set_mo_basis_coefficient_device(
 	ctx->mo_basis.uninitialized &= ~mask;
 	ctx->mo_basis.provided = (ctx->mo_basis.uninitialized == 0);
 	if (ctx->mo_basis.provided) {
-		qmckl_exit_code rc_ =
-			qmckl_finalize_mo_basis_device(context);
+		qmckl_exit_code rc_ = qmckl_finalize_mo_basis_device(context);
 		if (rc_ != QMCKL_SUCCESS)
 			return rc_;
 	}
@@ -2063,8 +2017,9 @@ qmckl_exit_code qmckl_set_mo_basis_coefficient_device(
 
 qmckl_exit_code
 qmckl_trexio_read_electron_X_device(qmckl_context_device context,
-										trexio_t *const file) {
+									trexio_t *const file) {
 
+	printf("[qmckl_trexio_read_electron_X_device] In\n");
 	assert(context != (qmckl_context_device)0);
 	assert(file != NULL);
 
@@ -2093,12 +2048,13 @@ qmckl_trexio_read_electron_X_device(qmckl_context_device context,
 
 	qmckl_exit_code rc;
 	rc = qmckl_set_electron_num_device(context, up_num, dn_num);
+	printf("[qmckl_trexio_read_electron_X_device] Out\n");
 	return rc;
 }
 
-qmckl_exit_code
-qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
-									   trexio_t *const file) {
+qmckl_exit_code qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
+												   trexio_t *const file) {
+	printf("[qmckl_trexio_read_nucleus_X_device] In\n");
 	assert(context != (qmckl_context)0);
 	assert(file != NULL);
 
@@ -2125,18 +2081,19 @@ qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
 		mem_info.size = nucleus_num * sizeof(double);
 
 		double *nucl_charge_h = (double *)qmckl_malloc_host(context, mem_info);
-		double *nucl_charge_d = (double *)qmckl_malloc_device(context, mem_info);
+		double *nucl_charge_d =
+			(double *)qmckl_malloc_device(context, mem_info);
 
 		if (nucl_charge_h == NULL || nucl_charge_d == NULL) {
-			return qmckl_failwith(
-				(qmckl_context)context, QMCKL_ALLOCATION_FAILED,
-				"qmckl_trexio_read_nucleus_X_device", NULL);
+			return qmckl_failwith((qmckl_context)context,
+								  QMCKL_ALLOCATION_FAILED,
+								  "qmckl_trexio_read_nucleus_X_device", NULL);
 		}
 
 		assert(nucl_charge_h != NULL && nucl_charge_d != NULL);
 
-		rcio =
-			trexio_read_safe_nucleus_charge_64(file, nucl_charge_h, nucleus_num);
+		rcio = trexio_read_safe_nucleus_charge_64(file, nucl_charge_h,
+												  nucleus_num);
 		if (rcio != TREXIO_SUCCESS) {
 			return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 								  "trexio_read_nucleus_charge",
@@ -2145,7 +2102,7 @@ qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
 
 		qmckl_memcpy_H2D(context, nucl_charge_d, nucl_charge_h, mem_info.size);
 		rc = qmckl_set_nucleus_charge_device(context, nucl_charge_d,
-												 nucleus_num);
+											 nucleus_num);
 
 		qmckl_free_host(context, nucl_charge_h);
 		qmckl_free_device(context, nucl_charge_d);
@@ -2169,7 +2126,8 @@ qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
 
 	assert(nucl_coord_h != NULL && nucl_coord_d != NULL);
 
-	rcio = trexio_read_safe_nucleus_coord_64(file, nucl_coord_h, 3 * nucleus_num);
+	rcio =
+		trexio_read_safe_nucleus_coord_64(file, nucl_coord_h, 3 * nucleus_num);
 	if (rcio != TREXIO_SUCCESS) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
 							  "trexio_read_nucleus_charge",
@@ -2177,8 +2135,8 @@ qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
 	}
 
 	qmckl_memcpy_H2D(context, nucl_coord_d, nucl_coord_h, mem_info.size);
-	rc = qmckl_set_nucleus_coord_device(
-		(qmckl_context)context, 'N', nucl_coord_d, 3 * nucleus_num);
+	rc = qmckl_set_nucleus_coord_device((qmckl_context)context, 'N',
+										nucl_coord_d, 3 * nucleus_num);
 
 	qmckl_free_host(context, nucl_coord_h);
 	qmckl_free_device(context, nucl_coord_d);
@@ -2189,11 +2147,13 @@ qmckl_trexio_read_nucleus_X_device(qmckl_context_device context,
 		return rc;
 	}
 
+	printf("[qmckl_trexio_read_nucleus_X_device] Out\n");
 	return QMCKL_SUCCESS;
 }
 
 qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
-												  trexio_t *const file) {
+											  trexio_t *const file) {
+	printf("[qmckl_trexio_read_ao_X_device] In\n");
 	assert(context != (qmckl_context)0);
 	assert(file != NULL);
 
@@ -2208,6 +2168,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 #define MAX_STR_LEN 1024
 	char basis_type[MAX_STR_LEN];
 
+	printf("[qmckl_trexio_read_ao_X_device] 0\n");
 	rcio = trexio_read_basis_type(file, basis_type, MAX_STR_LEN);
 	if (rcio != TREXIO_SUCCESS) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
@@ -2227,6 +2188,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 
 	int64_t shell_num = 0L;
 
+	printf("[qmckl_trexio_read_ao_X_device] 1\n");
 	rcio = trexio_read_basis_shell_num_64(file, &shell_num);
 	if (rcio != TREXIO_SUCCESS) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
@@ -2257,6 +2219,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 
 	int64_t ao_num = 0LL;
 
+	printf("[qmckl_trexio_read_ao_X_device] 2\n");
 	rcio = trexio_read_ao_num_64(file, &ao_num);
 	if (rcio != TREXIO_SUCCESS) {
 		return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
@@ -2270,16 +2233,17 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 	if (rc != QMCKL_SUCCESS)
 		return rc;
 
+	printf("[qmckl_trexio_read_ao_X_device] 3\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
 		/* Allocate array for data */
 		mem_info.size = nucleus_num * sizeof(int64_t);
+		size_t size_backup = mem_info.size;
 		int64_t *nucleus_index_h =
 			(int64_t *)qmckl_malloc_host(context, mem_info);
 		int64_t *nucleus_index_d =
 			(int64_t *)qmckl_malloc_device(context, mem_info);
-
 
 		if (nucleus_index_h == NULL || nucleus_index_d == NULL) {
 			return qmckl_failwith((qmckl_context)context,
@@ -2325,9 +2289,8 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		}
 
 		/* Reformat data */
-		qmckl_memcpy_H2D(context, nucleus_index_d, nucleus_index_h, mem_info.size);
-		rc = qmckl_set_ao_basis_nucleus_index_device(
-			context, nucleus_index_d, nucleus_num);
+		rc = qmckl_set_ao_basis_nucleus_index_device(context, nucleus_index_d,
+													 nucleus_num);
 		if (rc != QMCKL_SUCCESS) {
 			qmckl_free_host(context, nucleus_index_h);
 			qmckl_free_device(context, nucleus_index_d);
@@ -2352,12 +2315,15 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			nucleus_index_h[k] = i;
 		}
 
+		qmckl_memcpy_H2D(context, nucleus_index_d, nucleus_index_h,
+						 size_backup);
+
 		qmckl_free_host(context, tmp_array);
 		tmp_array = NULL;
 
 		/* Store data */
 		rc = qmckl_set_ao_basis_nucleus_index_device(context, nucleus_index_d,
-														 shell_num);
+													 shell_num);
 
 		qmckl_free_host(context, nucleus_index_h);
 		qmckl_free_device(context, nucleus_index_d);
@@ -2368,11 +2334,14 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
+	printf("[qmckl_trexio_read_ao_X_device] 4\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
 		/* Allocate array for data */
 		mem_info.size = nucleus_num * sizeof(int64_t);
+		size_t size_backup = mem_info.size;
+
 		int64_t *nucleus_shell_num_h =
 			(int64_t *)qmckl_malloc_host(context, mem_info);
 		int64_t *nucleus_shell_num_d =
@@ -2443,7 +2412,8 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		tmp_array = NULL;
 
 		/* Store data */
-		qmckl_memcpy_H2D(context, nucleus_shell_num_d, nucleus_shell_num_h, mem_info.size);
+		qmckl_memcpy_H2D(context, nucleus_shell_num_d, nucleus_shell_num_h,
+						 size_backup);
 		rc = qmckl_set_ao_basis_nucleus_shell_num_device(
 			context, nucleus_shell_num_d, shell_num);
 
@@ -2456,6 +2426,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
+	printf("[qmckl_trexio_read_ao_X_device] 5\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2466,7 +2437,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			(int32_t *)qmckl_malloc_host(context, mem_info);
 		int32_t *shell_ang_mom_d =
 			(int32_t *)qmckl_malloc_device(context, mem_info);
-
 
 		if (shell_ang_mom_h == NULL || shell_ang_mom_d == NULL) {
 			return qmckl_failwith((qmckl_context)context,
@@ -2492,9 +2462,10 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		}
 
 		/* Store data */
-		qmckl_memcpy_H2D(context, shell_ang_mom_d, shell_ang_mom_h, mem_info.size);
+		qmckl_memcpy_H2D(context, shell_ang_mom_d, shell_ang_mom_h,
+						 mem_info.size);
 		rc = qmckl_set_ao_basis_shell_ang_mom_device(context, shell_ang_mom_d,
-														 shell_num);
+													 shell_num);
 
 		qmckl_free_host(context, shell_ang_mom_h);
 		qmckl_free_device(context, shell_ang_mom_d);
@@ -2505,17 +2476,18 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
+	printf("[qmckl_trexio_read_ao_X_device] 6\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
 		/* Allocate array for data */
 		mem_info.size = shell_num * sizeof(int64_t);
+		size_t size_backup = mem_info.size;
 
 		int64_t *shell_prim_num_h =
 			(int64_t *)qmckl_malloc_host(context, mem_info);
 		int64_t *shell_prim_num_d =
 			(int64_t *)qmckl_malloc_device(context, mem_info);
-
 
 		if (shell_prim_num_h == NULL || shell_prim_num_d == NULL) {
 			return qmckl_failwith((qmckl_context)context,
@@ -2582,9 +2554,10 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		tmp_array = NULL;
 
 		/* Store data */
-		qmckl_memcpy_H2D(context, shell_prim_num_d, shell_prim_num_h, mem_info.size);
-		rc = qmckl_set_ao_basis_shell_prim_num_device(
-			context, shell_prim_num_d, shell_num);
+		qmckl_memcpy_H2D(context, shell_prim_num_d, shell_prim_num_h,
+						 size_backup);
+		rc = qmckl_set_ao_basis_shell_prim_num_device(context, shell_prim_num_d,
+													  shell_num);
 
 		qmckl_free_host(context, shell_prim_num_h);
 		qmckl_free_device(context, shell_prim_num_d);
@@ -2595,17 +2568,18 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
+	printf("[qmckl_trexio_read_ao_X_device] 7\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
 		/* Allocate array for data */
 		mem_info.size = shell_num * sizeof(int64_t);
+		size_t size_backup = mem_info.size;
 
 		int64_t *shell_prim_index_h =
 			(int64_t *)qmckl_malloc_host(context, mem_info);
 		int64_t *shell_prim_index_d =
 			(int64_t *)qmckl_malloc_device(context, mem_info);
-
 
 		if (shell_prim_index_h == NULL || shell_prim_index_d == NULL) {
 			return qmckl_failwith((qmckl_context)context,
@@ -2667,7 +2641,8 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		tmp_array = NULL;
 
 		/* Store data */
-		qmckl_memcpy_H2D(context, shell_prim_index_d, shell_prim_index_h, mem_info.size);
+		qmckl_memcpy_H2D(context, shell_prim_index_d, shell_prim_index_h,
+						 size_backup);
 		rc = qmckl_set_ao_basis_shell_prim_index_device(
 			context, shell_prim_index_d, shell_num);
 
@@ -2680,6 +2655,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
+	printf("[qmckl_trexio_read_ao_X_device] 8\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2687,7 +2663,8 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		mem_info.size = shell_num * sizeof(double);
 
 		double *shell_factor_h = (double *)qmckl_malloc_host(context, mem_info);
-		double *shell_factor_d = (double *)qmckl_malloc_device(context, mem_info);
+		double *shell_factor_d =
+			(double *)qmckl_malloc_device(context, mem_info);
 
 		if (shell_factor_h == NULL || shell_factor_d == NULL) {
 			return qmckl_failwith(
@@ -2711,9 +2688,10 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		}
 
 		/* Store data */
-		qmckl_memcpy_H2D(context, shell_factor_d, shell_factor_h, mem_info.size);
+		qmckl_memcpy_H2D(context, shell_factor_d, shell_factor_h,
+						 mem_info.size);
 		rc = qmckl_set_ao_basis_shell_factor_device(context, shell_factor_d,
-														shell_num);
+													shell_num);
 
 		qmckl_free_host(context, shell_factor_h);
 		qmckl_free_device(context, shell_factor_d);
@@ -2724,6 +2702,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
+	printf("[qmckl_trexio_read_ao_X_device] 9\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2766,6 +2745,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
+	printf("[qmckl_trexio_read_ao_X_device] 10\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2773,7 +2753,8 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		mem_info.size = prim_num * sizeof(double);
 
 		double *coefficient_h = (double *)qmckl_malloc_host(context, mem_info);
-		double *coefficient_d = (double *)qmckl_malloc_device(context, mem_info);
+		double *coefficient_d =
+			(double *)qmckl_malloc_device(context, mem_info);
 
 		if (coefficient_h == NULL || coefficient_d == NULL) {
 			return qmckl_failwith(
@@ -2784,8 +2765,8 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		assert(coefficient_h != NULL && coefficient_d != NULL);
 
 		/* Read data */
-		rcio =
-			trexio_read_safe_basis_coefficient_64(file, coefficient_h, prim_num);
+		rcio = trexio_read_safe_basis_coefficient_64(file, coefficient_h,
+													 prim_num);
 		if (rcio != TREXIO_SUCCESS) {
 			qmckl_free_host(context, coefficient_h);
 			qmckl_free_device(context, coefficient_d);
@@ -2799,7 +2780,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Store data */
 		qmckl_memcpy_H2D(context, coefficient_d, coefficient_h, mem_info.size);
 		rc = qmckl_set_ao_basis_coefficient_device(context, coefficient_d,
-													   prim_num);
+												   prim_num);
 
 		qmckl_free_host(context, coefficient_h);
 		qmckl_free_device(context, coefficient_d);
@@ -2810,6 +2791,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
+	printf("[qmckl_trexio_read_ao_X_device] 11\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2817,7 +2799,8 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		mem_info.size = prim_num * sizeof(double);
 
 		double *prim_factor_h = (double *)qmckl_malloc_host(context, mem_info);
-		double *prim_factor_d = (double *)qmckl_malloc_device(context, mem_info);
+		double *prim_factor_d =
+			(double *)qmckl_malloc_device(context, mem_info);
 
 		if (prim_factor_h == NULL || prim_factor_d == NULL) {
 			return qmckl_failwith(
@@ -2828,8 +2811,8 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		assert(prim_factor_h != NULL && prim_factor_d != NULL);
 
 		/* Read data */
-		rcio =
-			trexio_read_safe_basis_prim_factor_64(file, prim_factor_h, prim_num);
+		rcio = trexio_read_safe_basis_prim_factor_64(file, prim_factor_h,
+													 prim_num);
 		if (rcio != TREXIO_SUCCESS) {
 			qmckl_free_host(context, prim_factor_h);
 			qmckl_free_device(context, prim_factor_d);
@@ -2843,7 +2826,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		/* Read data */
 		qmckl_memcpy_H2D(context, prim_factor_d, prim_factor_h, mem_info.size);
 		rc = qmckl_set_ao_basis_prim_factor_device(context, prim_factor_d,
-													   prim_num);
+												   prim_num);
 
 		qmckl_free_host(context, prim_factor_h);
 		qmckl_free_device(context, prim_factor_d);
@@ -2854,6 +2837,7 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
+	printf("[qmckl_trexio_read_ao_X_device] 12\n");
 	{
 		qmckl_memory_info_struct mem_info = qmckl_memory_info_struct_zero;
 
@@ -2864,7 +2848,6 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			(double *)qmckl_malloc_host(context, mem_info);
 		double *ao_normalization_d =
 			(double *)qmckl_malloc_device(context, mem_info);
-
 
 		if (ao_normalization_h == NULL || ao_normalization_d == NULL) {
 			return qmckl_failwith(
@@ -2888,9 +2871,10 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 		}
 
 		/* Store data */
-		qmckl_memcpy_H2D(context, ao_normalization_d, ao_normalization_h, mem_info.size);
+		qmckl_memcpy_H2D(context, ao_normalization_d, ao_normalization_h,
+						 mem_info.size);
 		rc = qmckl_set_ao_basis_ao_factor_device(context, ao_normalization_d,
-													 ao_num);
+												 ao_num);
 
 		qmckl_free_host(context, ao_normalization_h);
 		qmckl_free_device(context, ao_normalization_d);
@@ -2901,11 +2885,13 @@ qmckl_exit_code qmckl_trexio_read_ao_X_device(qmckl_context context,
 			return rc;
 	}
 
+	printf("[qmckl_trexio_ao_X_device] Out\n");
 	return QMCKL_SUCCESS;
 }
 
 qmckl_exit_code qmckl_trexio_read_mo_X_device(qmckl_context_device context,
-												  trexio_t *const file) {
+											  trexio_t *const file) {
+	printf("[qmckl_trexio_mo_X_device] In\n");
 	assert(context != (qmckl_context_device)0);
 	assert(file != NULL);
 
@@ -2966,12 +2952,14 @@ qmckl_exit_code qmckl_trexio_read_mo_X_device(qmckl_context_device context,
 			return rc;
 	}
 
+	printf("[qmckl_trexio_mo_X_device] Out\n");
 	return QMCKL_SUCCESS;
 }
 
 qmckl_exit_code qmckl_trexio_read_device(const qmckl_context_device context,
-											 const char *file_name,
-											 const int64_t size_max) {
+										 const char *file_name,
+										 const int64_t size_max) {
+	printf("[qmckl_trexio_read_device] In\n");
 	if (qmckl_context_check((qmckl_context)context) == QMCKL_NULL_CONTEXT) {
 		return false;
 	}
@@ -3011,8 +2999,7 @@ qmckl_exit_code qmckl_trexio_read_device(const qmckl_context_device context,
 	if (rc != QMCKL_SUCCESS) {
 		trexio_close(file);
 		return qmckl_failwith((qmckl_context)context, QMCKL_FAILURE,
-							  "qmckl_trexio_read_device",
-							  "Error reading AOs");
+							  "qmckl_trexio_read_device", "Error reading AOs");
 	}
 
 	rc = qmckl_trexio_read_mo_X_device(context, file);
@@ -3024,5 +3011,6 @@ qmckl_exit_code qmckl_trexio_read_device(const qmckl_context_device context,
 
 	trexio_close(file);
 	file = NULL;
+	printf("[qmckl_trexio_read_device] Out\n");
 	return rc;
 }


### PR DESCRIPTION
- With the new interfaces, all functions now accept device pointers only (which was not always the case and could be confusing)
- AO computation on device pointers has also been converted to the new version (based on the Fortran documentation CPU version)