### PR TITLE
Fix bug in qmckl_context_create_device and .h file

### DIFF
--- a/include/qmckl_gpu.h
+++ b/include/qmckl_gpu.h
@@ -14,11 +14,8 @@ typedef int64_t qmckl_context_device;
 
 qmckl_context_device
 qmckl_context_touch_device(const qmckl_context_device context);
-qmckl_context_device
-qmckl_context_touch_device(const qmckl_context_device context);
 
 qmckl_context_device qmckl_context_create_device(int device_id);
-qmckl_context_device qmckl_context_create_device();
 
 qmckl_exit_code
 qmckl_context_destroy_device(const qmckl_context_device context);

--- a/src/qmckl_context_device.c
+++ b/src/qmckl_context_device.c
@@ -22,11 +22,16 @@ qmckl_context_device qmckl_context_create_device(int device_id) {
 		(qmckl_context_device)qmckl_context_create();
 	qmckl_context_struct *const ctx = (qmckl_context_struct *)context;
 
-	qmckl_context_device_struct *const ds =
-		(qmckl_context_device_struct *)ctx->qmckl_extra;
-
 	/* Allocate the qmckl_context_device_struct */
 	ctx->qmckl_extra = malloc(sizeof(qmckl_context_device_struct));
+
+
+	qmckl_context_device_struct *const ds =
+		(qmckl_context_device_struct *)ctx->qmckl_extra;
+	if(ds == NULL){
+		printf("%p\n", ds);
+
+	}
 
 	/* Allocate qmckl_memory_struct */
 	const size_t size = 128L;


### PR DESCRIPTION
change alloc position inside qmckl_context_create_device to avoid bug with ds variable.
remove bad declaration of qmckl_context_create_device in qmckl_gpu.h