### PR TITLE
cuBLAS in device-pointers library + D2Dcopy openACC workaround

### DIFF
--- a/include/qmckl_gpu.h
+++ b/include/qmckl_gpu.h
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
-#ifdef HAVE_CUBLAS then
+#ifdef HAVE_CUBLAS 
 #include <cublas_v2.h>
 #include <cusolverDn.h>
 #endif

--- a/src/qmckl_memory_acc.c
+++ b/src/qmckl_memory_acc.c
@@ -183,7 +183,20 @@ qmckl_exit_code qmckl_memcpy_D2D(qmckl_context_device context, void *dest,
 	}
 
 	qmckl_lock((qmckl_context)context);
-	{ acc_memcpy_to_device(dest, src, size); }
+	{ 
+      // NOT working from device to device
+      // acc_memcpy_to_device(dest, src, size); 
+      // 
+      // NOT fully supported
+      // int dest_dev_id = 0; 
+      // int src_dev_id = 0; 
+      // acc_memcpy_d2d(dest, src, size, dest_dev_id, src_dev_id); 
+      //
+      // Workaround (cast as int if multiple of 4 bytes?)
+      #pragma acc parallel loop gang vector deviceptr(src,dest), copyin(size)
+      for (int i=0;i<size;++i) 
+        ((char*)dest)[i] = ((char*)src)[i];
+    }
 	qmckl_unlock((qmckl_context)context);
 
 	return QMCKL_SUCCESS;

--- a/src/qmckl_mo.c
+++ b/src/qmckl_mo.c
@@ -1,9 +1,57 @@
 #include "include/qmckl_ao.h"
 #include "include/qmckl_mo.h"
+#ifdef HAVE_CUBLAS 
+#include <cublas_v2.h>
+#endif
 
 //**********
 // COMPUTE
 //**********
+//
+#ifdef HAVE_CUBLAS
+qmckl_exit_code
+qmckl_compute_mo_basis_mo_vgl_cublas_device (const qmckl_context          context,
+                                             const int64_t                ao_num,
+                                             const int64_t                mo_num,
+                                             const int64_t                point_num,
+                                             const double* restrict       coefficient_t,
+                                             const double* restrict       ao_vgl,
+                                                   double* restrict const mo_vgl )
+{
+  assert (context != QMCKL_NULL_CONTEXT);
+
+  cublasHandle_t handle;
+
+  double const alpha =  1.;
+  double const beta  =  0.;
+
+  cublasOperation_t transa = CUBLAS_OP_N ;
+  cublasOperation_t transb = CUBLAS_OP_N ;
+
+  // NB: cublas views arrays as column-major (ie FORTRAN-like) ordered
+  int const m = mo_num ; 
+  int const k = ao_num ;
+  int const n = point_num * 5 ;
+
+  int const lda = m ;
+  int const ldb = k ;
+  int const ldc = m ;
+
+ cublasCreate(&handle);
+//    printf("co %p\n",coefficient_t);
+//    printf("ao %p\n",ao_vgl);
+//    printf("mo %p\n",mo_vgl);
+// #pragma omp target data use_device_ptr(coefficient_t, ao_vgl, mo_vgl)
+// {
+//    double my_alpha = alpha;
+//    double my_beta  = beta;
+    cublasDgemm_v2( handle, transa, transb, m, n, k, &alpha, coefficient_t, lda, ao_vgl, ldb, &beta, mo_vgl, ldc );
+// }
+ cublasDestroy(handle);
+
+  return QMCKL_SUCCESS;
+}
+#endif
 
 /* mo_select */
 

--- a/src/qmckl_mo.c
+++ b/src/qmckl_mo.c
@@ -38,15 +38,7 @@ qmckl_compute_mo_basis_mo_vgl_cublas_device (const qmckl_context          contex
   int const ldc = m ;
 
  cublasCreate(&handle);
-//    printf("co %p\n",coefficient_t);
-//    printf("ao %p\n",ao_vgl);
-//    printf("mo %p\n",mo_vgl);
-// #pragma omp target data use_device_ptr(coefficient_t, ao_vgl, mo_vgl)
-// {
-//    double my_alpha = alpha;
-//    double my_beta  = beta;
-    cublasDgemm_v2( handle, transa, transb, m, n, k, &alpha, coefficient_t, lda, ao_vgl, ldb, &beta, mo_vgl, ldc );
-// }
+ cublasDgemm_v2( handle, transa, transb, m, n, k, &alpha, coefficient_t, lda, ao_vgl, ldb, &beta, mo_vgl, ldc );
  cublasDestroy(handle);
 
   return QMCKL_SUCCESS;

--- a/src/qmckl_mo.c
+++ b/src/qmckl_mo.c
@@ -121,10 +121,17 @@ qmckl_exit_code qmckl_provide_mo_basis_mo_vgl_device(qmckl_context context) {
 								  NULL);
 		}
 
+#ifdef HAVE_CUBLAS
+		rc = qmckl_compute_mo_basis_mo_vgl_cublas_device(
+			context, ctx->ao_basis.ao_num, ctx->mo_basis.mo_num, ctx->point.num,
+			ctx->mo_basis.coefficient_t, ctx->ao_basis.ao_vgl,
+			ctx->mo_basis.mo_vgl);
+#else
 		rc = qmckl_compute_mo_basis_mo_vgl_device(
 			context, ctx->ao_basis.ao_num, ctx->mo_basis.mo_num, ctx->point.num,
 			ctx->mo_basis.coefficient_t, ctx->ao_basis.ao_vgl,
 			ctx->mo_basis.mo_vgl);
+#endif
 
 		if (rc != QMCKL_SUCCESS) {
 			return rc;

--- a/src/qmckl_mo_omp.c
+++ b/src/qmckl_mo_omp.c
@@ -1,7 +1,4 @@
 #include "include/qmckl_mo.h"
-#ifdef HAVE_CUBLAS 
-#include <cublas_v2.h>
-#endif
 
 //**********
 // COMPUTE
@@ -9,50 +6,6 @@
 
 /* mo_vgl */
 
-#ifdef HAVE_CUBLAS
-qmckl_exit_code
-qmckl_compute_mo_basis_mo_vgl_cublas_device (const qmckl_context          context,
-                                             const int64_t                ao_num,
-                                             const int64_t                mo_num,
-                                             const int64_t                point_num,
-                                             const double* restrict       coefficient_t,
-                                             const double* restrict       ao_vgl,
-                                                   double* restrict const mo_vgl )
-{
-  assert (context != QMCKL_NULL_CONTEXT);
-
-  cublasHandle_t handle;
-
-  double const alpha =  1.;
-  double const beta  =  0.;
-
-  cublasOperation_t transa = CUBLAS_OP_N ;
-  cublasOperation_t transb = CUBLAS_OP_N ;
-
-  // NB: cublas views arrays as column-major (ie FORTRAN-like) ordered
-  int const m = mo_num ; 
-  int const k = ao_num ;
-  int const n = point_num * 5 ;
-
-  int const lda = m ;
-  int const ldb = k ;
-  int const ldc = m ;
-
- cublasCreate(&handle);
-    printf("co %p\n",coefficient_t);
-    printf("ao %p\n",ao_vgl);
-    printf("mo %p\n",mo_vgl);
-#pragma omp target data use_device_ptr(coefficient_t, ao_vgl, mo_vgl)
- {
-    double my_alpha = alpha;
-    double my_beta  = beta;
-    cublasDgemm_v2( handle, transa, transb, m, n, k, &my_alpha, coefficient_t, lda, ao_vgl, ldb, &my_beta, mo_vgl, ldc );
- }
- cublasDestroy(handle);
-
-  return QMCKL_SUCCESS;
-}
-#endif
 
 qmckl_exit_code qmckl_compute_mo_basis_mo_vgl_device(
 	qmckl_context context, int64_t ao_num, int64_t mo_num, int64_t point_num,

--- a/src/qmckl_mo_omp.c
+++ b/src/qmckl_mo_omp.c
@@ -1,10 +1,58 @@
 #include "include/qmckl_mo.h"
+#ifdef HAVE_CUBLAS 
+#include <cublas_v2.h>
+#endif
 
 //**********
 // COMPUTE
 //**********
 
 /* mo_vgl */
+
+#ifdef HAVE_CUBLAS
+qmckl_exit_code
+qmckl_compute_mo_basis_mo_vgl_cublas_device (const qmckl_context          context,
+                                             const int64_t                ao_num,
+                                             const int64_t                mo_num,
+                                             const int64_t                point_num,
+                                             const double* restrict       coefficient_t,
+                                             const double* restrict       ao_vgl,
+                                                   double* restrict const mo_vgl )
+{
+  assert (context != QMCKL_NULL_CONTEXT);
+
+  cublasHandle_t handle;
+
+  double const alpha =  1.;
+  double const beta  =  0.;
+
+  cublasOperation_t transa = CUBLAS_OP_N ;
+  cublasOperation_t transb = CUBLAS_OP_N ;
+
+  // NB: cublas views arrays as column-major (ie FORTRAN-like) ordered
+  int const m = mo_num ; 
+  int const k = ao_num ;
+  int const n = point_num * 5 ;
+
+  int const lda = m ;
+  int const ldb = k ;
+  int const ldc = m ;
+
+ cublasCreate(&handle);
+    printf("co %p\n",coefficient_t);
+    printf("ao %p\n",ao_vgl);
+    printf("mo %p\n",mo_vgl);
+#pragma omp target data use_device_ptr(coefficient_t, ao_vgl, mo_vgl)
+ {
+    double my_alpha = alpha;
+    double my_beta  = beta;
+    cublasDgemm_v2( handle, transa, transb, m, n, k, &my_alpha, coefficient_t, lda, ao_vgl, ldb, &my_beta, mo_vgl, ldc );
+ }
+ cublasDestroy(handle);
+
+  return QMCKL_SUCCESS;
+}
+#endif
 
 qmckl_exit_code qmckl_compute_mo_basis_mo_vgl_device(
 	qmckl_context context, int64_t ao_num, int64_t mo_num, int64_t point_num,


### PR DESCRIPTION
- cuBLAS for MOs can be called by the device-pointers libraries (both openMP and openACC).
- Fixed device-to-device copy with workaround in openACC device-pointers library (thanks to M. Bettencourt).