### PR TITLE
cuSPARSE in device-pointers

### DIFF
--- a/include/qmckl_gpu.h
+++ b/include/qmckl_gpu.h
@@ -14,6 +14,11 @@
 #include <cusolverDn.h>
 #endif
 
+#ifdef HAVE_CUSPARSE 
+#include <cuda_runtime_api.h>
+#include <cusparse_v2.h>
+#endif
+
 /* CPU */
 typedef int32_t qmckl_exit_code;
 typedef int64_t qmckl_context;

--- a/src/qmckl_ao_acc_offload.c
+++ b/src/qmckl_ao_acc_offload.c
@@ -1,4 +1,5 @@
 #include "include/qmckl_ao.h"
+#define qmckl_ten3(t, i, j, k) t.data[(i) + t.size[0]*((j) + t.size[1]*(k))]
 
 //**********
 // COMPUTE

--- a/src/qmckl_ao_omp_offload.c
+++ b/src/qmckl_ao_omp_offload.c
@@ -1,4 +1,6 @@
 #include "include/qmckl_ao.h"
+#define qmckl_ten3(t, i, j, k) t.data[(i) + t.size[0]*((j) + t.size[1]*(k))]
+
 
 //**********
 // COMPUTE

--- a/src/qmckl_memory_acc.c
+++ b/src/qmckl_memory_acc.c
@@ -187,7 +187,7 @@ qmckl_exit_code qmckl_memcpy_D2D(qmckl_context_device context, void *dest,
       // NOT working from device to device
       // acc_memcpy_to_device(dest, src, size); 
       // 
-      // NOT fully supported
+      // NOT supporting device-pointers only
       // int dest_dev_id = 0; 
       // int src_dev_id = 0; 
       // acc_memcpy_d2d(dest, src, size, dest_dev_id, src_dev_id); 

--- a/src/qmckl_mo_acc_offload.c
+++ b/src/qmckl_mo_acc_offload.c
@@ -1,14 +1,14 @@
 #include "include/qmckl_mo.h"
 
-#ifdef _CUBLAS then
+#ifdef HAVE_CUBLAS 
 #include <cublas_v2.h>
 #endif
 
-#ifdef _NVBLAS then
+#ifdef HAVE_NVBLAS 
 #include <nvblas.h>
 #endif
 
-#ifdef _CUSPARSE then
+#ifdef HAVE_CUSPARSE 
 #include <cuda_runtime_api.h>
 #include <cusparse_v2.h>
 #endif
@@ -174,13 +174,13 @@ qmckl_exit_code qmckl_compute_mo_basis_mo_vgl_acc_offload(
 	const qmckl_context context, const int64_t ao_num, const int64_t mo_num,
 	const int64_t point_num, const double *coefficient_t, const double *ao_vgl,
 	double *const mo_vgl) {
-#if defined(_CUBLAS)
+#if defined(HAVE_CUBLAS)
 	return qmckl_compute_mo_basis_mo_vgl_cublas_acc_offload(
 		context, ao_num, mo_num, point_num, coefficient_t, ao_vgl, mo_vgl);
-#elif defined(_CUSPARSE)
+#elif defined(HAVE_CUSPARSE)
 	return qmckl_compute_mo_basis_mo_vgl_cusparse_acc_offload(
 		context, ao_num, mo_num, point_num, coefficient_t, ao_vgl, mo_vgl);
-#elif defined(_NVBLAS)
+#elif defined(HAVE_NVBLAS)
 	return qmckl_compute_mo_basis_mo_vgl_nvblas_acc_offload(
 		context, ao_num, mo_num, point_num, coefficient_t, ao_vgl, mo_vgl);
 #else
@@ -191,7 +191,7 @@ qmckl_exit_code qmckl_compute_mo_basis_mo_vgl_acc_offload(
 #endif
 }
 
-#if defined(_CUSPARSE)
+#if defined(HAVE_CUSPARSE)
 qmckl_exit_code qmckl_compute_mo_basis_mo_vgl_cusparse_acc_offload(
 	const qmckl_context context, const int64_t ao_num, const int64_t mo_num,
 	const int64_t point_num, const double *restrict coefficient_t,
@@ -303,7 +303,7 @@ qmckl_exit_code qmckl_compute_mo_basis_mo_vgl_cusparse_acc_offload(
 }
 #endif
 
-#if defined(_NVBLAS)
+#if defined(HAVE_NVBLAS)
 qmckl_exit_code qmckl_compute_mo_basis_mo_vgl_nvblas_acc_offload(
 	const qmckl_context context, const int64_t ao_num, const int64_t mo_num,
 	const int64_t point_num, const double *restrict coefficient_t,
@@ -334,7 +334,7 @@ qmckl_exit_code qmckl_compute_mo_basis_mo_vgl_nvblas_acc_offload(
 }
 #endif
 
-#if defined(_CUBLAS)
+#if defined(HAVE_CUBLAS)
 qmckl_exit_code qmckl_compute_mo_basis_mo_vgl_cublas_acc_offload(
 	const qmckl_context context, const int64_t ao_num, const int64_t mo_num,
 	const int64_t point_num, const double *restrict coefficient_t,


### PR DESCRIPTION
- Activated with -DHAVE_CUSPARSE (to be added manually for the time being, configure.ac still to be updated).
- cusparse implementation needs cuda version >=11.8.
- Compile error at linking level with nvidia compiler
 ```
nvlink fatal   : Input file 'src/.libs/qmckl_mo.o' newer than toolkit (118 vs 110)
```
 with the openMP branch, possibly due to inconsistencies of cuda versions. Is this error reproduced elsewhere?