### PR TITLE
some missing functions fortran interface

### DIFF
--- a/include/qmckl_gpu_f.f90
+++ b/include/qmckl_gpu_f.f90
@@ -2,6 +2,7 @@ module qmckl_gpu_f
     use, intrinsic :: iso_c_binding
     integer, parameter :: qmckl_context_device = c_int64_t
     integer, parameter :: qmckl_exit_code_device = c_int32_t
+    integer(qmckl_exit_code_device), parameter :: QMCKL_SUCCESS_DEVICE  = 0
     interface
 
     !!!!!!!!!!!
@@ -69,6 +70,17 @@ module qmckl_gpu_f
             integer(qmckl_context_device), intent(in), value :: context
             type(c_ptr), intent(in), value :: ptr
         end function qmckl_free_device
+        
+        integer(qmckl_exit_code_device) function qmckl_free_host(context, ptr) &
+            bind(C, name="qmckl_free_host")
+            use, intrinsic :: iso_c_binding
+            import
+            implicit none
+
+            integer(qmckl_context_device), intent(in), value :: context
+            type(c_ptr), intent(in), value :: ptr
+        end function qmckl_free_host
+          
 
         integer(qmckl_exit_code_device) function qmckl_memcpy_H2D(context, dest, src, size) &
             bind(C, name="qmckl_memcpy_H2D")
@@ -425,7 +437,18 @@ module qmckl_gpu_f
         end function qmckl_set_ao_basis_ao_factor_device
 
         ! Getters (calling compute)
+        
+        integer(qmckl_exit_code_device) function qmckl_get_ao_basis_ao_num_device(context, ao_num) &
+            bind(C, name="qmckl_get_ao_basis_ao_num_device")
+            use, intrinsic :: iso_c_binding
+            import
+            implicit none
 
+            integer(qmckl_context_device), intent(in), value :: context
+            integer(c_int64_t), intent(in), value :: ao_num
+        end function qmckl_get_ao_basis_ao_num_device
+
+        
         integer(qmckl_exit_code_device) function qmckl_get_ao_basis_ao_vgl_device(context, ao_vgl, size_max) &
             bind(C, name="qmckl_get_ao_basis_ao_vgl_device")
             use, intrinsic :: iso_c_binding
@@ -436,6 +459,8 @@ module qmckl_gpu_f
             type(c_ptr), intent(in), value :: ao_vgl
             integer(c_int64_t), intent(in), value :: size_max
         end function qmckl_get_ao_basis_ao_vgl_device
+
+        
 
         integer(qmckl_exit_code_device) function qmckl_get_ao_basis_ao_value_device(context, ao_value, size_max) &
             bind(C, name="qmckl_get_ao_basis_ao_value_device")


### PR DESCRIPTION
Dear

@justemax, @PurplePachyderm , @scemama 

Happy new year!. Please, can you review these simple changes?. I just added couple functions where missing in the interface to compile it with CHAMP. I just modified the include/qmck_gpu_f.f90, it seems ok and it builds the library. Please let me know if something is missing.  
  
best, 

Edgar