### PR TITLE
fix possible problems const double pointers

### DIFF
--- a/include/qmckl_gpu.h
+++ b/include/qmckl_gpu.h
@@ -513,7 +513,7 @@ qmckl_exit_code_device qmckl_distance_rescaled_device(
 
 qmckl_exit_code_device qmckl_set_point_device(qmckl_context_device context,
 											  char transp, int64_t num,
-											  double *coord, int64_t size_max);
+											  const double *coord, int64_t size_max);
 
 qmckl_exit_code_device
 qmckl_get_point_device(const qmckl_context_device context, const char transp,
@@ -572,7 +572,7 @@ qmckl_set_electron_num_device(qmckl_context_device context, int64_t up_num,
 
 qmckl_exit_code_device
 qmckl_set_electron_coord_device(qmckl_context_device context, char transp,
-								int64_t walk_num, double *coord,
+								int64_t walk_num, const double *coord,
 								int64_t size_max);
 
 qmckl_exit_code_device


### PR DESCRIPTION
Hi @justemax and @scemama 

I think, I just found a bug,  this is important I guess to ensure safe memory allocation in the set_point, set_electron_coord functions. 

Please, let me know if this is correct.  By the wya, I think it wont fix any of the problems I observed interfacing with Champ. 

best, 

Edgar